### PR TITLE
Disable access to external entities in XML parsing #56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Unit test for DocValidator and FreemarkerDocProcessConfigValidator (#56)
+
+### Fixed
+
+- Prohibit xml external entities on DocValidator and FreemarkerDocProcessConfigValidator (#56)
+
+### Changed
+
+- Added assertions to TestPOI junit
+
 ## [1.5.7] - 2023-09-01
 
 ### Added

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/xml/DocValidator.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/xml/DocValidator.java
@@ -84,10 +84,10 @@ public class DocValidator {
 		}
 	}
 	
-	private static String getXsdVersion( Reader xmlReader ) throws XMLException {
+	public static String getXsdVersion( Reader xmlReader ) throws XMLException {
 		String version = null;
 		try {
-			SAXParserFactory spf = SAXParserFactory.newInstance();
+			SAXParserFactory spf = SAXUtils.newSafeFactory();
 			spf.setNamespaceAware( true );
 			final Properties infos = new Properties();
 			SAXParser parser = spf.newSAXParser();

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/xml/SAXUtils.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/xml/SAXUtils.java
@@ -1,0 +1,34 @@
+package org.fugerit.java.doc.base.xml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.SAXParserFactory;
+
+import org.fugerit.java.core.cfg.ConfigRuntimeException;
+
+public class SAXUtils {
+
+	private SAXUtils() {}
+	
+	public static SAXParserFactory newFactory( Map<String, Boolean> features ) {
+		SAXParserFactory factory = SAXParserFactory.newInstance();
+		for ( String key : features.keySet() ) {
+			boolean value = features.get( key );
+			try {
+				factory.setFeature( key, value );
+			} catch (Exception e) {
+				throw ConfigRuntimeException.convertExMethod("newFactory", e);
+			}
+		}
+		return factory;
+	}
+	
+	public static SAXParserFactory newSafeFactory() {
+		Map<String, Boolean> features = new HashMap<>();
+		features.put( "http://xml.org/sax/features/external-general-entities" , false );
+		features.put( "http://xml.org/sax/features/external-parameter-entities" , false );
+		return newFactory( features );
+	}
+	
+}

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/xml/SAXUtils.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/xml/SAXUtils.java
@@ -11,24 +11,27 @@ public class SAXUtils {
 
 	private SAXUtils() {}
 	
-	public static SAXParserFactory newFactory( Map<String, Boolean> features ) {
+	private static final Map<String, Boolean> NO_FEATURES = new HashMap<>();
+	
+	public static SAXParserFactory newSafeFactory( Map<String, Boolean> features ) {
 		SAXParserFactory factory = SAXParserFactory.newInstance();
-		for ( String key : features.keySet() ) {
-			boolean value = features.get( key );
-			try {
+		try {
+			factory.setFeature( "http://xml.org/sax/features/external-general-entities" , false );
+			factory.setFeature( "http://xml.org/sax/features/external-parameter-entities" , false );
+			// additional features if any
+			for ( String key : features.keySet() ) {
+				boolean value = features.get( key );
 				factory.setFeature( key, value );
-			} catch (Exception e) {
-				throw ConfigRuntimeException.convertExMethod("newFactory", e);
 			}
+		} catch (Exception e) {
+			throw ConfigRuntimeException.convertExMethod("newFactory", e);
 		}
+		
 		return factory;
 	}
 	
 	public static SAXParserFactory newSafeFactory() {
-		Map<String, Boolean> features = new HashMap<>();
-		features.put( "http://xml.org/sax/features/external-general-entities" , false );
-		features.put( "http://xml.org/sax/features/external-parameter-entities" , false );
-		return newFactory( features );
+		return newSafeFactory(NO_FEATURES);
 	}
 	
 }

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/xml/SAXUtils.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/xml/SAXUtils.java
@@ -7,6 +7,9 @@ import javax.xml.parsers.SAXParserFactory;
 
 import org.fugerit.java.core.cfg.ConfigRuntimeException;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class SAXUtils {
 
 	private SAXUtils() {}
@@ -19,9 +22,9 @@ public class SAXUtils {
 			factory.setFeature( "http://xml.org/sax/features/external-general-entities" , false );
 			factory.setFeature( "http://xml.org/sax/features/external-parameter-entities" , false );
 			// additional features if any
-			for ( String key : features.keySet() ) {
-				boolean value = features.get( key );
-				factory.setFeature( key, value );
+			for ( Map.Entry<String,Boolean> entry : features.entrySet() ) {
+				log.trace( "set feature {} -> {}", entry.getKey(), entry.getValue() );
+				factory.setFeature( entry.getKey(), entry.getValue() );
 			}
 		} catch (Exception e) {
 			throw ConfigRuntimeException.convertExMethod("newFactory", e);

--- a/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/xml/ReaderFail.java
+++ b/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/xml/ReaderFail.java
@@ -1,0 +1,21 @@
+package test.org.fugerit.java.doc.base.xml;
+
+import java.io.IOException;
+import java.io.Reader;
+
+public class ReaderFail extends Reader {
+
+	@Override
+	public int read(char[] cbuf, int off, int len) throws IOException {
+		if ( cbuf != null ) {
+			throw new IOException( "Must fail for test" );
+		}
+		return 0;
+	}
+
+	@Override
+	public void close() throws IOException {
+		// no need to do something
+	}
+
+}

--- a/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/xml/TestDocValidator.java
+++ b/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/xml/TestDocValidator.java
@@ -1,0 +1,129 @@
+package test.org.fugerit.java.doc.base.xml;
+
+import static org.junit.Assert.fail;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import org.fugerit.java.core.lang.helpers.ClassHelper;
+import org.fugerit.java.core.xml.XMLException;
+import org.fugerit.java.core.xml.sax.SAXParseResult;
+import org.fugerit.java.doc.base.xml.DocValidator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TestDocValidator {
+
+	private static final String VALID_XML_PATH = "sample/doc_test_01.xml";
+	
+	private void failEx( Exception e ) {
+		String message = "Error : "+e.getMessage();
+		log.error( message, e );
+		fail( message );
+	}
+	
+	@Test
+	public void testValidate() {
+		String fullPath = VALID_XML_PATH;
+		log.info( "validate -> {}", fullPath );
+		try ( InputStream is = ClassHelper.loadFromDefaultClassLoader( fullPath );
+				Reader reader = new InputStreamReader(is)) {
+			SAXParseResult result = DocValidator.validate( reader );
+			boolean ok = result.isPartialSuccess();
+			DocValidator.logResult(result, log);
+			log.info( "Validation result {}", ok );
+			Assert.assertTrue( ok );
+		} catch (Exception e) {
+			this.failEx(e);
+		}
+	}
+	
+	@Test
+	public void testValidateVersion() {
+		String fullPath = VALID_XML_PATH;
+		log.info( "validate -> {}", fullPath );
+		try ( InputStream is = ClassHelper.loadFromDefaultClassLoader( fullPath );
+				Reader reader = new InputStreamReader(is)) {
+			SAXParseResult result = DocValidator.validateVersion( reader );
+			boolean ok = result.isPartialSuccess();
+			DocValidator.logResult(result, log);
+			log.info( "Validation result {}", ok );
+			Assert.assertTrue( ok );
+		} catch (Exception e) {
+			this.failEx(e);
+		}
+	}
+	
+	@Test
+	public void testValidateLoggerKo() {
+		String fullPath = "sample/doc_test_02_ko.xml";
+		log.info( "validate -> {}", fullPath );
+		try ( InputStream is = ClassHelper.loadFromDefaultClassLoader( fullPath );
+				Reader reader = new InputStreamReader(is)) {
+			boolean ok = DocValidator.logValidation(reader, log);
+			log.info( "Validation result {}", ok );
+			Assert.assertTrue( !ok );
+		} catch (Exception e) {
+			this.failEx(e);
+		}
+	}
+	
+	@Test
+	public void testValidateLoggerOk() {
+		String fullPath = VALID_XML_PATH;
+		log.info( "validate -> {}", fullPath );
+		try ( InputStream is = ClassHelper.loadFromDefaultClassLoader( fullPath );
+				Reader reader = new InputStreamReader(is)) {
+			boolean ok = DocValidator.logValidation(reader, log);
+			log.info( "Validation result {}", ok );
+			Assert.assertTrue( ok );
+		} catch (Exception e) {
+			this.failEx(e);
+		}
+	}
+	
+	@Test
+	public void testValidateFail() {
+		try ( Reader reader = new ReaderFail() ) {
+			SAXParseResult result = DocValidator.validate( reader );
+			fail( "Should not get here : "+result );
+		} catch (Exception e) {
+			Assert.assertTrue( e instanceof XMLException );
+		}
+	}
+
+	@Test
+	public void testValidateVersionFail() {
+		try ( Reader reader = new ReaderFail() ) {
+			SAXParseResult result = DocValidator.validateVersion( reader );
+			fail( "Should not get here : "+result );
+		} catch (Exception e) {
+			Assert.assertTrue( e instanceof XMLException );
+		}
+	}
+
+	@Test
+	public void testValidateLoggerFail() {
+		try ( Reader reader = new ReaderFail() ) {
+			boolean result = DocValidator.logValidation( reader, log );
+			fail( "Should not get here : "+result );
+		} catch (Exception e) {
+			Assert.assertTrue( e instanceof XMLException );
+		}
+	}
+	
+	@Test
+	public void testGetXsdVersion() {
+		try ( Reader reader = new ReaderFail() ) {
+			String result = DocValidator.getXsdVersion(reader);
+			fail( "Should not get here : "+result );
+		} catch (Exception e) {
+			Assert.assertTrue( e instanceof XMLException );
+		}
+	}
+		
+}

--- a/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/xml/TestSAXUtils.java
+++ b/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/xml/TestSAXUtils.java
@@ -37,8 +37,9 @@ public class TestSAXUtils {
 	public void testNewInstanceFail() {
 		try {
 			Map<String, Boolean> features = new HashMap<>();
+			features.put( "http://xml.org/sax/features/external-general-entities" , false);
 			features.put( "feature-not-exists" , false);
-			SAXParserFactory factory = SAXUtils.newFactory(features);
+			SAXParserFactory factory = SAXUtils.newSafeFactory(features);
 			fail( "Should not arrive here "+factory );
 		} catch (Exception e) {
 			Assert.assertTrue( e instanceof ConfigRuntimeException );

--- a/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/xml/TestSAXUtils.java
+++ b/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/xml/TestSAXUtils.java
@@ -1,0 +1,49 @@
+package test.org.fugerit.java.doc.base.xml;
+
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.SAXParserFactory;
+
+import org.fugerit.java.core.cfg.ConfigRuntimeException;
+import org.fugerit.java.doc.base.xml.SAXUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TestSAXUtils {
+
+	private void failEx( Exception e ) {
+		String message = "Error : "+e.getMessage();
+		log.error( message, e );
+		fail( message );
+	}
+	
+	@Test
+	public void testNewSafeInstance() {
+		try {
+			SAXParserFactory factory = SAXUtils.newSafeFactory();
+			Assert.assertTrue( factory != null );
+		} catch (Exception e) {
+			this.failEx(e);
+		}
+	}
+	
+	@Test
+	public void testNewInstanceFail() {
+		try {
+			Map<String, Boolean> features = new HashMap<>();
+			features.put( "feature-not-exists" , false);
+			SAXParserFactory factory = SAXUtils.newFactory(features);
+			fail( "Should not arrive here "+factory );
+		} catch (Exception e) {
+			Assert.assertTrue( e instanceof ConfigRuntimeException );
+		}
+	}
+
+}
+

--- a/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/xml/TestSAXUtils.java
+++ b/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/xml/TestSAXUtils.java
@@ -27,7 +27,7 @@ public class TestSAXUtils {
 	public void testNewSafeInstance() {
 		try {
 			SAXParserFactory factory = SAXUtils.newSafeFactory();
-			Assert.assertTrue( factory != null );
+			Assert.assertNotNull( factory );
 		} catch (Exception e) {
 			this.failEx(e);
 		}

--- a/fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/process/FreemarkerDocProcessConfigValidator.java
+++ b/fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/process/FreemarkerDocProcessConfigValidator.java
@@ -22,6 +22,7 @@ import org.fugerit.java.core.xml.sax.eh.ResultErrorHandler;
 import org.fugerit.java.doc.base.model.DocBase;
 import org.fugerit.java.doc.base.parser.DocParserContext;
 import org.fugerit.java.doc.base.xml.DocContentHandler;
+import org.fugerit.java.doc.base.xml.SAXUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -66,10 +67,10 @@ public class FreemarkerDocProcessConfigValidator {
 		return result;
 	}
 	
-	private static String getXsdVersion( Reader xmlReader ) throws XMLException {
+	public static String getXsdVersion( Reader xmlReader ) throws XMLException {
 		String version = null;
 		try {
-			SAXParserFactory spf = SAXParserFactory.newInstance();
+			SAXParserFactory spf = SAXUtils.newSafeFactory();
 			spf.setNamespaceAware( true );
 			final Properties infos = new Properties();
 			SAXParser parser = spf.newSAXParser();

--- a/fj-doc-freemarker/src/test/java/test/org/fugerit/java/doc/freemarker/process/ReaderFail.java
+++ b/fj-doc-freemarker/src/test/java/test/org/fugerit/java/doc/freemarker/process/ReaderFail.java
@@ -1,0 +1,21 @@
+package test.org.fugerit.java.doc.freemarker.process;
+
+import java.io.IOException;
+import java.io.Reader;
+
+public class ReaderFail extends Reader {
+
+	@Override
+	public int read(char[] cbuf, int off, int len) throws IOException {
+		if ( cbuf != null ) {
+			throw new IOException( "Must fail for test" );
+		}
+		return 0;
+	}
+
+	@Override
+	public void close() throws IOException {
+		// no need to do something
+	}
+
+}

--- a/fj-doc-freemarker/src/test/java/test/org/fugerit/java/doc/freemarker/process/TestFreemarkerDocProcessConfigValidator.java
+++ b/fj-doc-freemarker/src/test/java/test/org/fugerit/java/doc/freemarker/process/TestFreemarkerDocProcessConfigValidator.java
@@ -1,0 +1,129 @@
+package test.org.fugerit.java.doc.freemarker.process;
+
+import static org.junit.Assert.fail;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import org.fugerit.java.core.lang.helpers.ClassHelper;
+import org.fugerit.java.core.xml.XMLException;
+import org.fugerit.java.core.xml.sax.SAXParseResult;
+import org.fugerit.java.doc.freemarker.process.FreemarkerDocProcessConfigValidator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TestFreemarkerDocProcessConfigValidator {
+
+	private static final String VALID_XML_PATH = "fj_doc_test/freemarker-doc-process.xml";
+	
+	private void failEx( Exception e ) {
+		String message = "Error : "+e.getMessage();
+		log.error( message, e );
+		fail( message );
+	}
+	
+	@Test
+	public void testValidate() {
+		String fullPath = VALID_XML_PATH;
+		log.info( "validate -> {}", fullPath );
+		try ( InputStream is = ClassHelper.loadFromDefaultClassLoader( fullPath );
+				Reader reader = new InputStreamReader(is)) {
+			SAXParseResult result = FreemarkerDocProcessConfigValidator.validate( reader );
+			boolean ok = result.isPartialSuccess();
+			FreemarkerDocProcessConfigValidator.logResult(result);
+			log.info( "Validation result {}", ok );
+			Assert.assertTrue( ok );
+		} catch (Exception e) {
+			this.failEx(e);
+		}
+	}
+	
+	@Test
+	public void testValidateVersion() {
+		String fullPath = VALID_XML_PATH;
+		log.info( "validate -> {}", fullPath );
+		try ( InputStream is = ClassHelper.loadFromDefaultClassLoader( fullPath );
+				Reader reader = new InputStreamReader(is)) {
+			SAXParseResult result = FreemarkerDocProcessConfigValidator.validateVersion( reader );
+			boolean ok = result.isPartialSuccess();
+			FreemarkerDocProcessConfigValidator.logResult(result);
+			log.info( "Validation result {}", ok );
+			Assert.assertTrue( ok );
+		} catch (Exception e) {
+			this.failEx(e);
+		}
+	}
+	
+	@Test
+	public void testValidateLoggerKo() {
+		String fullPath = "fj_doc_test/freemarker-doc-process_ko.xml";
+		log.info( "validate -> {}", fullPath );
+		try ( InputStream is = ClassHelper.loadFromDefaultClassLoader( fullPath );
+				Reader reader = new InputStreamReader(is)) {
+			boolean ok = FreemarkerDocProcessConfigValidator.logValidation(reader);
+			log.info( "Validation result {}", ok );
+			Assert.assertTrue( !ok );
+		} catch (Exception e) {
+			this.failEx(e);
+		}
+	}
+	
+	@Test
+	public void testValidateLoggerOk() {
+		String fullPath = VALID_XML_PATH;
+		log.info( "validate -> {}", fullPath );
+		try ( InputStream is = ClassHelper.loadFromDefaultClassLoader( fullPath );
+				Reader reader = new InputStreamReader(is)) {
+			boolean ok = FreemarkerDocProcessConfigValidator.logValidation(reader);
+			log.info( "Validation result {}", ok );
+			Assert.assertTrue( ok );
+		} catch (Exception e) {
+			this.failEx(e);
+		}
+	}
+	
+	@Test
+	public void testValidateFail() {
+		try ( Reader reader = new ReaderFail() ) {
+			SAXParseResult result = FreemarkerDocProcessConfigValidator.validate( reader );
+			fail( "Should not get here : "+result );
+		} catch (Exception e) {
+			Assert.assertTrue( e instanceof XMLException );
+		}
+	}
+
+	@Test
+	public void testValidateVersionFail() {
+		try ( Reader reader = new ReaderFail() ) {
+			SAXParseResult result = FreemarkerDocProcessConfigValidator.validateVersion( reader );
+			fail( "Should not get here : "+result );
+		} catch (Exception e) {
+			Assert.assertTrue( e instanceof XMLException );
+		}
+	}
+
+	@Test
+	public void testValidateLoggerFail() {
+		try ( Reader reader = new ReaderFail() ) {
+			boolean result = FreemarkerDocProcessConfigValidator.logValidation( reader );
+			fail( "Should not get here : "+result );
+		} catch (Exception e) {
+			Assert.assertTrue( e instanceof XMLException );
+		}
+	}
+	
+	@Test
+	public void testGetXsdVersion() {
+		try ( Reader reader = new ReaderFail() ) {
+			String result = FreemarkerDocProcessConfigValidator.getXsdVersion(reader);
+			fail( "Should not get here : "+result );
+		} catch (Exception e) {
+			Assert.assertTrue( e instanceof XMLException );
+		}
+	}
+	
+}

--- a/fj-doc-freemarker/src/test/resources/fj_doc_test/freemarker-doc-process_ko.xml
+++ b/fj-doc-freemarker/src/test/resources/fj_doc_test/freemarker-doc-process_ko.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<freemarker-doc-process-config
+	xmlns="https://freemarkerdocprocess.fugerit.org"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://freemarkerdocprocess.fugerit.org https://www.fugerit.org/data/java/doc/xsd/freemarker-doc-process-1-0.xsd" > 	
+
+	<docChain id="shared">
+		<chainStep stepType="config" attribute-not-exists="test">
+			<config id="FJ_DOC_TEST"
+				version="2.3.31"
+				path="/fj_doc_test/template/"
+				mode="class" 
+				class="org.fugerit.java.doc.freemarker.process.FreemarkerDocProcessConfigFacade"
+				exception-handler="RETHROW_HANDLER"
+				log-exception="false"
+				wrap-unchecked-exceptions="true"
+				fallback-on-null-loop-variable="false"/>
+		</chainStep>
+		<chainStep stepType="function">
+			<function name="messageFormat" value="org.fugerit.java.doc.freemarker.fun.SimpleMessageFun"/>
+			<function name="sumLong" value="org.fugerit.java.doc.freemarker.fun.SimpleSumLongFun"/>
+		</chainStep>
+	</docChain>
+
+	<docChain id="sample_chain" parent="shared">
+		<chainStep stepType="complex" template-path="${chainId}.ftl"/>
+	</docChain>
+
+</freemarker-doc-process-config>

--- a/fj-doc-sample/src/test/java/test/org/fugerit/java/doc/sample/format/TestPOI.java
+++ b/fj-doc-sample/src/test/java/test/org/fugerit/java/doc/sample/format/TestPOI.java
@@ -12,6 +12,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.Assert;
 import org.junit.Test;
 
 import test.org.fugerit.java.doc.sample.facade.BasicFacadeTest;
@@ -29,6 +30,7 @@ public class TestPOI extends TestFormatBase {
 	
 	@Test
 	public void testCellForegroundColor() throws Exception  {
+		boolean ok = false;
 		String test = "cell_foreground_color";
 		Workbook workbook = new XSSFWorkbook();
 		Sheet sheet = workbook.createSheet( test );
@@ -47,6 +49,9 @@ public class TestPOI extends TestFormatBase {
 		
 		cell.setCellStyle( style );
 		close( workbook, test );
+		ok = true;
+		Assert.assertTrue(ok);
 	}
+	
 
 }


### PR DESCRIPTION
### Added

- Unit test for DocValidator and FreemarkerDocProcessConfigValidator (#56)

### Fixed

- Prohibit xml external entities on DocValidator and FreemarkerDocProcessConfigValidator (#56)

### Changed

- Added assertions to TestPOI junit