### PR TITLE
[3.1.4] - 2023-10-14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fj-doc-freemarker] FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8 with default escapeTextAsHtml=true and UTF8 charset
 - [fj-doc-freemarker] output_format xml test
 
+### Changed
+
+- [fj-doc-freemarker] FreeMarkerHtmlTypeHandlerEscapeUTF8 and FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8 set as default for config stub generation
+
+### Removed
+
+- reference to fj-doc-mod-poi5 in README.md
+
 ## [3.1.3] - 2023-10-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [fj-doc-freemarker] config attribute for FreeMarkerDocHelperTypeHandler : escapeTextAsHtml
+- [fj-doc-freemarker] FreeMarkerHtmlTypeHandlerEscapeUTF8 with default escapeTextAsHtml=true and UTF8 charset
 - [fj-doc-freemarker] output_format xml test
 
 ## [3.1.3] - 2023-10-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.4] - 2023-10-14
+
 ### Added
 
+- [fj-doc-freemarker] config attribute for FreeMarkerDocHelperTypeHandler : escapeTextAsHtml
 - [fj-doc-freemarker] output_format xml test
 
 ## [3.1.3] - 2023-10-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [fj-doc-freemarker] output_format xml test
+
 ## [3.1.3] - 2023-10-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [fj-doc-freemarker] config attribute for FreeMarkerDocHelperTypeHandler : escapeTextAsHtml
 - [fj-doc-freemarker] FreeMarkerHtmlTypeHandlerEscapeUTF8 with default escapeTextAsHtml=true and UTF8 charset
+- [fj-doc-freemarker] FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8 with default escapeTextAsHtml=true and UTF8 charset
 - [fj-doc-freemarker] output_format xml test
 
 ## [3.1.3] - 2023-10-03

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ There are five kinds of components (each components README.md contains module st
 
 ### 2. Modules :
 * [FreeMarker template, (fj-doc-freemarker)](fj-doc-freemarker/README.md) (contains a simple renderer for [HTML](fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/html/FreeMarkerHtmlTypeHandler.java) and [HTML FRAGMENT](fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/html/FreeMarkerHtmlFragmentTypeHandler.java))
-* [Apache POI 4 Module (fj-doc-mod-poi)](fj-doc-mod-poi/README.md) ([XLS](fj-doc-mod-poi/src/main/java/org/fugerit/java/doc/mod/poi/XlsPoiTypeHandler.java)/[XLSX](fj-doc-mod-poi/src/main/java/org/fugerit/java/doc/mod/poi/XlsPoiTypeHandler.java))
-* [Apache POI 5 Module (fj-doc-mod-poi5)](fj-doc-mod-poi5/README.md) ([XLS](fj-doc-mod-poi5/src/main/java/org/fugerit/java/doc/mod/poi5/XlsPoi5TypeHandler.java)/[XLSX](fj-doc-mod-poi5/src/main/java/org/fugerit/java/doc/mod/poi5/XlsPoi5TypeHandler.java)) [requires java 11+, since 1.3.2]
+* [Apache POI Module (fj-doc-mod-poi)](fj-doc-mod-poi/README.md) ([XLS](fj-doc-mod-poi/src/main/java/org/fugerit/java/doc/mod/poi/XlsPoiTypeHandler.java)/[XLSX](fj-doc-mod-poi/src/main/java/org/fugerit/java/doc/mod/poi/XlsPoiTypeHandler.java))
 * [Apache FOP Module (fj-doc-mod-fop)](fj-doc-mod-fop/README.md) ([PDF](fj-doc-mod-fop/src/main/java/org/fugerit/java/doc/mod/fop/PdfFopTypeHandler.java)/[FO](fj-doc-mod-fop/src/main/java/org/fugerit/java/doc/mod/fop/FreeMarkerFopTypeHandler.java))
 * [OpenCSV Module (fj-doc-mod-opencsv)](fj-doc-mod-opencsv/README.md) ([CSV](fj-doc-mod-opencsv/src/main/java/org/fugerit/java/doc/mod/opencsv/OpenCSVTypeHandler.java))
 
@@ -43,9 +42,8 @@ There are five kinds of components (each components README.md contains module st
 * [MD EXT](fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/markdown/SimpleMarkdownExtTypeHandler.java) - (fj-doc-base) output as Markdown extended (include tables) language
 * [HTML](fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/html/FreeMarkerHtmlTypeHandler.java) - (fj-doc-freemarker) output as html
 * [HTML FRAGMENT](fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/html/FreeMarkerHtmlFragmentTypeHandler.java) - (fj-doc-freemarker) output as html body content only (no html, head or body tags)
-* [XLS](fj-doc-mod-poi/src/main/java/org/fugerit/java/doc/mod/poi/XlsPoiTypeHandler.java) - (fj-doc-mod-poi) output as Microsoft XLS using Apache POI 4
-* [XLSX](fj-doc-mod-poi/src/main/java/org/fugerit/java/doc/mod/poi/XlsPoiTypeHandler.java) - (fj-doc-mod-poi) output as Microsoft XLSX using Apache POI 4
-* [XLS](fj-doc-mod-poi5/src/main/java/org/fugerit/java/doc/mod/poi5/XlsPoi5TypeHandler.java) - (fj-doc-mod-poi5) output as Microsoft XLS using Apache POI 5
+* [XLS](fj-doc-mod-poi/src/main/java/org/fugerit/java/doc/mod/poi/XlsPoiTypeHandler.java) - (fj-doc-mod-poi) output as Microsoft XLS using Apache POI
+* [XLSX](fj-doc-mod-poi/src/main/java/org/fugerit/java/doc/mod/poi/XlsPoiTypeHandler.java) - (fj-doc-mod-poi) output as Microsoft XLSX using Apache POI
 * [XLSX](fj-doc-mod-poi5/src/main/java/org/fugerit/java/doc/mod/poi5/XlsPoi5TypeHandler.java) - (fj-doc-mod-poi5) output as Microsoft XLSX using Apache POI 5
 * [PDF](fj-doc-mod-fop/src/main/java/org/fugerit/java/doc/mod/fop/PdfFopTypeHandler.java) - (fj-doc-mod-fop) - output as PDF using Apache FOP
 * [FO](fj-doc-mod-fop/src/main/java/org/fugerit/java/doc/mod/fop/FreeMarkerFopTypeHandler.java) - (fj-doc-mod-fop) - output as FO using Apache FOP

--- a/fj-doc-base-json/pom.xml
+++ b/fj-doc-base-json/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-base-json</name>

--- a/fj-doc-base-yaml/pom.xml
+++ b/fj-doc-base-yaml/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-base-yaml</name>

--- a/fj-doc-base/pom.xml
+++ b/fj-doc-base/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-base</name>

--- a/fj-doc-freemarker/pom.xml
+++ b/fj-doc-freemarker/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-freemarker</name>

--- a/fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/helper/FreeMarkerDocHelperTypeHandler.java
+++ b/fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/helper/FreeMarkerDocHelperTypeHandler.java
@@ -74,16 +74,13 @@ public class FreeMarkerDocHelperTypeHandler extends DocTypeHandlerDefault {
 		chain.apply( context, data );
 		StreamIO.pipeCharCloseBoth( data.getCurrentXmlReader() , new OutputStreamWriter( docOutput.getOs(), this.getCharset() ) );
 	}
+	
+	
 
 	@Override
-	public void configure(Element tag) throws ConfigException {
-		super.configure(tag);
-		if ( tag != null ) {
-			Properties atts = DOMUtils.attributesToProperties( tag );
-			this.setEscapeTextAsHtml( BooleanUtils.isTrue( atts.getProperty( ATT_ESCAPE_TEXT_AS_HTML ) ) );
-		}
-	}
-	
-	
+	protected void handleConfigTag(Element config) throws ConfigException {
+		Properties atts = DOMUtils.attributesToProperties( config );
+		this.setEscapeTextAsHtml( BooleanUtils.isTrue( atts.getProperty( ATT_ESCAPE_TEXT_AS_HTML ) ) );
+	}	
 	
 }

--- a/fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/helper/FreeMarkerDocHelperTypeHandler.java
+++ b/fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/helper/FreeMarkerDocHelperTypeHandler.java
@@ -2,15 +2,23 @@ package org.fugerit.java.doc.freemarker.helper;
 
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
+import java.util.Properties;
 
+import org.fugerit.java.core.cfg.ConfigException;
 import org.fugerit.java.core.io.StreamIO;
+import org.fugerit.java.core.lang.helpers.BooleanUtils;
 import org.fugerit.java.core.util.filterchain.MiniFilterChain;
+import org.fugerit.java.core.xml.dom.DOMUtils;
 import org.fugerit.java.doc.base.config.DocCharsetProvider;
 import org.fugerit.java.doc.base.config.DocInput;
 import org.fugerit.java.doc.base.config.DocOutput;
 import org.fugerit.java.doc.base.config.DocTypeHandlerDefault;
 import org.fugerit.java.doc.base.process.DocProcessContext;
 import org.fugerit.java.doc.base.process.DocProcessData;
+import org.w3c.dom.Element;
+
+import lombok.Getter;
+import lombok.Setter;
 
 public class FreeMarkerDocHelperTypeHandler extends DocTypeHandlerDefault {
 
@@ -19,6 +27,9 @@ public class FreeMarkerDocHelperTypeHandler extends DocTypeHandlerDefault {
 	public static final String MODULE = "fm";
 	
 	public static final String CHAIN_FREEMARKER = "html-freemarker";
+	
+	public static final String ATT_ESCAPE_TEXT_AS_HTML = "escapeTextAsHtml";
+	public static final boolean ATT_ESCAPE_TEXT_AS_HTML_DEFAULT = false;
 	
 	public static final String MIME = "text/html";
 	
@@ -42,21 +53,37 @@ public class FreeMarkerDocHelperTypeHandler extends DocTypeHandlerDefault {
 	public FreeMarkerDocHelperTypeHandler(String type, Charset charset, String fmDocChainId) {
 		super(type, MODULE, MIME, charset);
 		this.fmDocChainId = fmDocChainId;
+		this.escapeTextAsHtml = ATT_ESCAPE_TEXT_AS_HTML_DEFAULT;
 	}
 
-	private String fmDocChainId;
+	@Getter private String fmDocChainId;
+
+	@Getter @Setter private boolean escapeTextAsHtml;
 	
-	public String getFmDocChainId() {
-		return fmDocChainId;
+	public FreeMarkerDocHelperTypeHandler withEscapeTextAsHtml( boolean value ) {
+		this.setEscapeTextAsHtml(value);
+		return this;
 	}
-
+	
 	@Override
 	public void handle(DocInput docInput, DocOutput docOutput) throws Exception {
 		MiniFilterChain chain = FreeMarkerDocProcess.getInstance().getChainCache( this.getFmDocChainId() );
-		DocProcessContext context = DocProcessContext.newContext().withDocInput( docInput );
+		DocProcessContext context = DocProcessContext.newContext()
+				.withDocInput( docInput ).withAtt( ATT_ESCAPE_TEXT_AS_HTML ,this.isEscapeTextAsHtml() );
 		DocProcessData data = new DocProcessData();
 		chain.apply( context, data );
 		StreamIO.pipeCharCloseBoth( data.getCurrentXmlReader() , new OutputStreamWriter( docOutput.getOs(), this.getCharset() ) );
 	}
+
+	@Override
+	public void configure(Element tag) throws ConfigException {
+		super.configure(tag);
+		if ( tag != null ) {
+			Properties atts = DOMUtils.attributesToProperties( tag );
+			this.setEscapeTextAsHtml( BooleanUtils.isTrue( atts.getProperty( ATT_ESCAPE_TEXT_AS_HTML ) ) );
+		}
+	}
+	
+	
 	
 }

--- a/fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/html/FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8.java
+++ b/fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/html/FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8.java
@@ -1,0 +1,22 @@
+package org.fugerit.java.doc.freemarker.html;
+
+import java.nio.charset.StandardCharsets;
+
+import org.fugerit.java.doc.base.config.DocTypeHandler;
+import org.fugerit.java.doc.base.config.DocTypeHandlerDecorator;
+
+public class FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8 extends DocTypeHandlerDecorator {
+
+	public static final DocTypeHandler HANDLER = new FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8();
+	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -7394516771708L;
+
+	public FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8() {
+		super( new FreeMarkerHtmlFragmentTypeHandler( StandardCharsets.UTF_8 ).withEscapeTextAsHtml( true ) );
+		
+	}
+	
+}

--- a/fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/html/FreeMarkerHtmlTypeHandlerEscapeUTF8.java
+++ b/fj-doc-freemarker/src/main/java/org/fugerit/java/doc/freemarker/html/FreeMarkerHtmlTypeHandlerEscapeUTF8.java
@@ -1,0 +1,21 @@
+package org.fugerit.java.doc.freemarker.html;
+
+import java.nio.charset.StandardCharsets;
+
+import org.fugerit.java.doc.base.config.DocTypeHandler;
+import org.fugerit.java.doc.base.config.DocTypeHandlerDecorator;
+
+public class FreeMarkerHtmlTypeHandlerEscapeUTF8 extends DocTypeHandlerDecorator {
+
+	public static final DocTypeHandler HANDLER = new FreeMarkerHtmlTypeHandlerEscapeUTF8();
+	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -7394516771708L;
+
+	public FreeMarkerHtmlTypeHandlerEscapeUTF8() {
+		super( new FreeMarkerHtmlTypeHandler(StandardCharsets.UTF_8).withEscapeTextAsHtml( true ) );
+	}
+	
+}

--- a/fj-doc-freemarker/src/main/resources/fj_doc_freemarker_config/fm-freemarker-doc-process-config.xml
+++ b/fj-doc-freemarker/src/main/resources/fj_doc_freemarker_config/fm-freemarker-doc-process-config.xml
@@ -22,6 +22,7 @@
 		<chainStep stepType="map">
 			<map name="docBase" value="docBase"/>
 			<map name="docType" value="docType"/>
+			<map name="escapeTextAsHtml" value="escapeTextAsHtml"/>
 		</chainStep>
 	</docChain>
 

--- a/fj-doc-freemarker/src/main/resources/fj_doc_freemarker_config/template/freemarker-doc-process-config-stub.ftl
+++ b/fj-doc-freemarker/src/main/resources/fj_doc_freemarker_config/template/freemarker-doc-process-config-stub.ftl
@@ -5,7 +5,7 @@
     xsi:schemaLocation="https://freemarkerdocprocess.fugerit.org https://www.fugerit.org/data/java/doc/xsd/freemarker-doc-process-1-0.xsd" > 	
 
 	<!--
-		Configuration stub version : 004 (2023-08-02)
+		Configuration stub version : 005 (2023-10-14)
 	-->
 
 	<#assign stubHandler=stubParams['stub-handler']!'1'>
@@ -19,9 +19,9 @@
 		<docHandler id="xml-doc" info="xml" type="org.fugerit.java.doc.base.config.DocTypeHandlerXMLUTF8" />
 	
 		<!-- Type handlers for html using freemarker --> 
-		<docHandler id="html-fm" info="html" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlTypeHandlerUTF8" />	
+		<docHandler id="html-fm" info="html" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlTypeHandlerEscapeUTF8" />	
 		<!-- Type handlers for html using freemarker (fragment version, only generates body content no html or head part --> 
-		<docHandler id="html-fragment-fm" info="fhtml" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlFragmentTypeHandlerUTF8" />
+		<docHandler id="html-fragment-fm" info="fhtml" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8" />
 		
 		<#assign enableFopBase=stubParams['enable-fop-base']!'0'>
 		<#assign enableFopFull=stubParams['enable-fop-full']!'0'>

--- a/fj-doc-freemarker/src/main/resources/fj_doc_freemarker_config/template/macro/feature-escape-html.ftl
+++ b/fj-doc-freemarker/src/main/resources/fj_doc_freemarker_config/template/macro/feature-escape-html.ftl
@@ -1,0 +1,1 @@
+<#macro printText e>${e.text?html}</#macro>

--- a/fj-doc-freemarker/src/main/resources/fj_doc_freemarker_config/template/macro/feature-escape-none.ftl
+++ b/fj-doc-freemarker/src/main/resources/fj_doc_freemarker_config/template/macro/feature-escape-none.ftl
@@ -1,0 +1,1 @@
+<#macro printText e>${e.text}</#macro>

--- a/fj-doc-freemarker/src/main/resources/fj_doc_freemarker_config/template/macro/html_element.ftl
+++ b/fj-doc-freemarker/src/main/resources/fj_doc_freemarker_config/template/macro/html_element.ftl
@@ -1,6 +1,12 @@
 <#global defaultBorderColor='black'>
 <#global defaultFontSize='10'>
 
+<#if escapeTextAsHtml!false>
+<#import "feature-escape-html.ftl" as escape>
+<#else>
+<#import "feature-escape-none.ftl" as escape>
+</#if>
+
 <#macro handleElement current>
 	<#assign elementType="${current.class.simpleName}"/>
 	<#if elementType = 'DocPhrase'>
@@ -29,19 +35,19 @@
 
 <#macro handlePhrase current>
 	<#if (current.link)??>
-		<a <@handleId element=current/><@handleStyleOnly styleValue=current.style/> href="${current.link}">${current.text}</a>
+		<a <@handleId element=current/><@handleStyleOnly styleValue=current.style/> href="${current.link}"><@escape.printText e=current/></a>
 	<#elseif (current.anchor)??>
-		<span <@handleId element=current/><@handleStyleOnly styleValue=current.style/>>${current.text}</span>
+		<span <@handleId element=current/><@handleStyleOnly styleValue=current.style/>><@escape.printText e=current/></span>
 	<#else>
-		<span <@handleId element=current/><@handleStyleOnly styleValue=current.style/>>${current.text}</span>
+		<span <@handleId element=current/><@handleStyleOnly styleValue=current.style/>><@escape.printText e=current/></span>
 	</#if>
 </#macro>
 
 <#macro handlePara current>
 	<#if current.headLevel == 0>
-		<p<@handleId element=current/><@handleStyleComplete element=current styleValue=current.originalStyle alignValue=current.align dc=current/>>${current.text}<#list current.elementList as currentChild><@handleElement current=currentChild/></#list></p>
+		<p<@handleId element=current/><@handleStyleComplete element=current styleValue=current.originalStyle alignValue=current.align dc=current/>><@escape.printText e=current/><#list current.elementList as currentChild><@handleElement current=currentChild/></#list></p>
 	<#else>
-		<h${current.headLevel} <@handleId element=current/><@handleStyleComplete element=current styleValue=current.style alignValue=current.align dc=current/>>${current.text}<#list current.elementList as currentChild><@handleElement current=currentChild/></#list></h${current.headLevel}>
+		<h${current.headLevel} <@handleId element=current/><@handleStyleComplete element=current styleValue=current.style alignValue=current.align dc=current/>><@escape.printText e=current/><#list current.elementList as currentChild><@handleElement current=currentChild/></#list></h${current.headLevel}>
 	</#if>
 </#macro>
 

--- a/fj-doc-freemarker/src/test/java/test/org/fugerit/java/doc/freemarker/process/TestFreemarkerDocProcessConfig.java
+++ b/fj-doc-freemarker/src/test/java/test/org/fugerit/java/doc/freemarker/process/TestFreemarkerDocProcessConfig.java
@@ -3,12 +3,14 @@ package test.org.fugerit.java.doc.freemarker.process;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.io.Reader;
 
 import org.fugerit.java.core.cfg.ConfigException;
 import org.fugerit.java.core.cfg.ConfigRuntimeException;
 import org.fugerit.java.core.function.SafeFunction;
+import org.fugerit.java.core.io.FileIO;
 import org.fugerit.java.core.lang.helpers.ClassHelper;
 import org.fugerit.java.doc.base.config.DocConfig;
 import org.fugerit.java.doc.base.config.DocOutput;
@@ -136,8 +138,10 @@ public class TestFreemarkerDocProcessConfig extends BasicTest {
 			// test process 1
 			try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() ) {
 				DocProcessData data = new DocProcessData();
-				config.process( "test_02" , DocProcessContext.newContext(), data, FreeMarkerHtmlTypeHandlerUTF8.HANDLER, DocOutput.newOutput(baos) );
+				config.process( "test_02" , DocProcessContext.newContext( "testKey", "<test/>" ), data, FreeMarkerHtmlTypeHandlerUTF8.HANDLER, DocOutput.newOutput(baos) );
 				Assert.assertNotEquals( 0 , data.getCurrentXmlData().length() );
+				File file = new File( "target/test_02.xml" );
+				FileIO.writeBytes( data.getCurrentXmlData().getBytes() , file );
 			}
 		} );
 	}

--- a/fj-doc-freemarker/src/test/resources/fj_doc_test/template/test_02.ftl
+++ b/fj-doc-freemarker/src/test/resources/fj_doc_test/template/test_02.ftl
@@ -1,3 +1,4 @@
+<#ftl output_format="XML">
 <?xml version="1.0" encoding="utf-8"?>
 <doc
 	xmlns="http://javacoredoc.fugerit.org"
@@ -29,7 +30,7 @@
   </meta>
  
   <body>
-    
+    	<para>${.output_format} - ${testKey!'not present'}</para>
     	<table columns="3" colwidths="30;30;40"  width="100" id="excel-table" padding="2">
     		<row>
     			<cell align="center" border-color="#ee0000" border-width="1"><para style="bold">Name</para></cell>

--- a/fj-doc-lib-autodoc/pom.xml
+++ b/fj-doc-lib-autodoc/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-lib-autodoc</name>

--- a/fj-doc-lib-simpletable-import/pom.xml
+++ b/fj-doc-lib-simpletable-import/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-lib-simpletable-import</name>

--- a/fj-doc-lib-simpletable/pom.xml
+++ b/fj-doc-lib-simpletable/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-lib-simpletable</name>

--- a/fj-doc-mod-fop/pom.xml
+++ b/fj-doc-mod-fop/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-mod-fop</name>

--- a/fj-doc-mod-opencsv/pom.xml
+++ b/fj-doc-mod-opencsv/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-mod-opencsv</name>

--- a/fj-doc-mod-poi/pom.xml
+++ b/fj-doc-mod-poi/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-mod-poi</name>

--- a/fj-doc-playground-quarkus/pom.xml
+++ b/fj-doc-playground-quarkus/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 	<artifactId>fj-doc-playground-quarkus</artifactId>
 	<properties>

--- a/fj-doc-sample/pom.xml
+++ b/fj-doc-sample/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-sample</name>

--- a/fj-doc-sample/src/main/resources/config/freemarker-doc-process.xml
+++ b/fj-doc-sample/src/main/resources/config/freemarker-doc-process.xml
@@ -36,8 +36,8 @@
 			-->
 			<docHandlerCustomConfig charset="UTF-8" fop-config-mode="classloader" fop-config-classloader-path="fop-config.xml" fop-suppress-events="1"/>
 		</docHandler>
-		<docHandler id="html-fm" info="html" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlTypeHandlerUTF8" />	
-		<docHandler id="html-fragment-fm" info="fhtml" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlFragmentTypeHandlerUTF8" />
+		<docHandler id="html-fm" info="html" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlTypeHandlerEscapeUTF8" />	
+		<docHandler id="html-fragment-fm" info="fhtml" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8" />
 		<docHandler id="csv-opencsv" info="csv" type="org.fugerit.java.doc.mod.opencsv.OpenCSVTypeHandler"/>		
 		<!-- test for unsafe DocTypeHandler: this class does not exist, the error will be traced but the initialization will end -->
 		<docHandler id="pdf-unsafe" info="pdf" type="org.fugerit.java.doc.pdf.UnsafeDocHandler" unsafe="true" unsafeMode="log-trace"/>

--- a/fj-doc-tool/pom.xml
+++ b/fj-doc-tool/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-tool</name>

--- a/fj-doc-val-core/pom.xml
+++ b/fj-doc-val-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-val-core</name>

--- a/fj-doc-val-pdfbox/pom.xml
+++ b/fj-doc-val-pdfbox/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-val-pdfbox</name>

--- a/fj-doc-val-poi/pom.xml
+++ b/fj-doc-val-poi/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-val-poi</name>

--- a/fj-doc-val/pom.xml
+++ b/fj-doc-val/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 
 	<name>fj-doc-val</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<artifactId>fj-doc</artifactId>
 
-	<version>3.1.3</version>
+	<version>3.1.4</version>
 	<packaging>pom</packaging>
 
 	<name>fj-doc</name>


### PR DESCRIPTION
## [3.1.4] - 2023-10-14

### Added

- [fj-doc-freemarker] config attribute for FreeMarkerDocHelperTypeHandler : escapeTextAsHtml
- [fj-doc-freemarker] FreeMarkerHtmlTypeHandlerEscapeUTF8 with default escapeTextAsHtml=true and UTF8 charset
- [fj-doc-freemarker] FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8 with default escapeTextAsHtml=true and UTF8 charset
- [fj-doc-freemarker] output_format xml test

### Changed

- [fj-doc-freemarker] FreeMarkerHtmlTypeHandlerEscapeUTF8 and FreeMarkerHtmlFragmentTypeHandlerEscapeUTF8 set as default for config stub generation

### Removed

- reference to fj-doc-mod-poi5 in README.md