### PR TITLE
Fix code scanning alert no. 103: Partial path traversal vulnerability from remote

### DIFF
--- a/fj-doc-playground-quarkus/src/main/java/org/fugerit/java/doc/playground/init/ProjectRest.java
+++ b/fj-doc-playground-quarkus/src/main/java/org/fugerit/java/doc/playground/init/ProjectRest.java
@@ -107,7 +107,7 @@ public class ProjectRest {
     }
     public static void checkIfInTempFolder( File file ) throws IOException {
         File tempDir = new File( System.getProperty("java.io.tmpdir") );
-        if ( !file.getCanonicalPath().startsWith( tempDir.getCanonicalPath() ) ) {
+        if ( !file.toPath().normalize().startsWith(tempDir.toPath().normalize()) ) {
             throw new IOException( file.getCanonicalPath() + " is not in temp folder" );
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/fugerit-org/fj-doc/security/code-scanning/103](https://github.com/fugerit-org/fj-doc/security/code-scanning/103)

To fix the partial path traversal vulnerability, we need to ensure that the base directory path (`tempDir`) is slash-terminated before checking if the user-supplied path (`file`) starts with it. This can be achieved by modifying the `checkIfInTempFolder` method to use `toPath().normalize()` for both the base directory and the user-supplied path, which provides a more robust way to check if one path is a subdirectory of another.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
