### PR TITLE
Fix native support for Apache FreeMarker #278

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix native support for Apache FreeMarker <https://github.com/fugerit-org/fj-doc/issues/278>
+- subfolder for native embedded configuration file <https://github.com/fugerit-org/fj-doc/issues/276>
+- freemarker-version 2.3.34
+- quarkus-version set to 3.17.6 across al the modules
+
 ## [8.11.8] - 2025-01-10
 
 ### Changed

--- a/fj-doc-freemarker/pom.xml
+++ b/fj-doc-freemarker/pom.xml
@@ -22,7 +22,8 @@
 	</licenses>
 	
 	<properties>
-		<freemarker-version>2.3.34</freemarker-version>	
+		<freemarker-version>2.3.34</freemarker-version>
+		<freemarker-native-version>1.0.0</freemarker-native-version>
 	</properties>
 	
 	<build>
@@ -77,6 +78,12 @@
 		    <groupId>org.freemarker</groupId>
 		    <artifactId>freemarker</artifactId>
 		    <version>${freemarker-version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.fugerit.java</groupId>
+			<artifactId>freemarker-native</artifactId>
+			<version>${freemarker-native-version}</version>
 		</dependency>
 
 		<dependency>

--- a/fj-doc-maven-plugin/src/main/java/org/fugerit/java/doc/project/facade/FlavourContext.java
+++ b/fj-doc-maven-plugin/src/main/java/org/fugerit/java/doc/project/facade/FlavourContext.java
@@ -66,4 +66,8 @@ public class FlavourContext {
         return VenusContext.toResourcePathFmConfigXml( this.getArtifactId() );
     }
 
+    public boolean isFreeMarkerNativeAvailable() {
+        return VersionCheck.isMajorThan( this.getVersion(), VenusContext.VERSION_NA_FREEMARKER_NATIVE );
+    }
+
 }

--- a/fj-doc-maven-plugin/src/main/java/org/fugerit/java/doc/project/facade/VenusContext.java
+++ b/fj-doc-maven-plugin/src/main/java/org/fugerit/java/doc/project/facade/VenusContext.java
@@ -37,6 +37,8 @@ public class VenusContext {
 
     public static final String VERSION_NA_FULL_PROCESS = "8.6.2";
 
+    public static final String VERSION_NA_FREEMARKER_NATIVE = "8.11.8";
+
     @Getter
     private File projectDir;
 

--- a/fj-doc-maven-plugin/src/main/resources/config/template/flavour/quarkus-3/pom.ftl
+++ b/fj-doc-maven-plugin/src/main/resources/config/template/flavour/quarkus-3/pom.ftl
@@ -15,7 +15,7 @@
         <quarkus.platform.version>${context.flavourVersion}</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.3.1</surefire-plugin.version>
-        <quarkus-freemarker-version>1.1.0</quarkus-freemarker-version>
+        <freemarker-native-version>1.0.0</freemarker-native-version>
     </properties>
 
     <dependencyManagement>
@@ -52,11 +52,13 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <#if context.modules?seq_contains("fj-doc-freemarker")>
+        <#if !context.freeMarkerNativeAvailable >
         <dependency>
-            <groupId>io.quarkiverse.freemarker</groupId>
-            <artifactId>quarkus-freemarker</artifactId>
-            <version>${r"${quarkus-freemarker-version}"}</version>
+            <groupId>io.fugerit.java</groupId>
+            <artifactId>freemarker-natice</artifactId>
+            <version>${r"${freemarker-native-version}"}</version>
         </dependency>
+        </#if>
         </#if>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/fj-doc-maven-plugin/src/test/java/test/org/fugerit/java/doc/project/facade/TestInit.java
+++ b/fj-doc-maven-plugin/src/test/java/test/org/fugerit/java/doc/project/facade/TestInit.java
@@ -9,6 +9,7 @@ import org.fugerit.java.doc.maven.MojoInit;
 import org.fugerit.java.doc.project.facade.FlavourContext;
 import org.fugerit.java.doc.project.facade.FlavourFacade;
 import org.fugerit.java.doc.project.facade.ModuleFacade;
+import org.fugerit.java.doc.project.facade.VenusContext;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -17,6 +18,8 @@ import java.util.UUID;
 
 @Slf4j
 public class TestInit {
+
+    private static final String FREEMARKER_NATIVE_AVAILABLE = "8.11.9";
 
     private String getVersion() {
         return "8.10.5";
@@ -81,6 +84,10 @@ public class TestInit {
         context.setFlavourVersion(  "test" );
         FlavourFacade.checkFlavourVersion( context, FlavourFacade.FLAVOUR_QUARKUS_2  );
         Assert.assertEquals( "test", context.getFlavourVersion() );
+        context.setVersion( VenusContext.VERSION_NA_FREEMARKER_NATIVE );
+        Assert.assertFalse( context.isFreeMarkerNativeAvailable() );
+        context.setVersion( FREEMARKER_NATIVE_AVAILABLE );
+        Assert.assertTrue( context.isFreeMarkerNativeAvailable() );
     }
 
 }

--- a/fj-doc-mod-opencsv/pom.xml
+++ b/fj-doc-mod-opencsv/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 
 	<name>fj-doc-mod-opencsv</name>
-	<description>Renderer for CSV using OpenCSV</description>
+	<description>Fugerit Venus Doc Module. Contains doc handler for CSV format (based on com.opencsv:opencsv).</description>
 
 	<licenses>
 		<license>

--- a/fj-doc-native-quarkus/pom.xml
+++ b/fj-doc-native-quarkus/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
     <surefire-plugin.version>3.5.2</surefire-plugin.version>
-    <quarkus-freemarker-version>1.1.0</quarkus-freemarker-version>
     <quarkus.platform.version>${quarkus-version}</quarkus.platform.version>
     <skipITs>true</skipITs>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -54,11 +53,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkiverse.freemarker</groupId>
-      <artifactId>quarkus-freemarker</artifactId>
-      <version>${quarkus-freemarker-version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
The following actions are taken : 

1. Added org.fugerit.java:freemarker-native dependency to fj-doc-freemarker
2. Removed quarkus-freemarker dependency from fj-doc-maven-plugin:init, quarkus-3 flavour
3. Removed quarkus-freemarker dependency from fj-doc-native-quarkus

Now it seems to work properly