### PR TITLE
298 bug use ubi9 based quarkus micro image for quarkus 3

### DIFF
--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle-kts/src/main/docker/Dockerfile.jvm
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle-kts/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle-kts/src/main/docker/Dockerfile.legacy-jar
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle-kts/src/main/docker/Dockerfile.legacy-jar
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle-kts/src/main/docker/Dockerfile.native
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle-kts/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/fj-doc-quarkus-tutorial
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle-kts/src/main/docker/Dockerfile.native-micro
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle-kts/src/main/docker/Dockerfile.native-micro
@@ -17,7 +17,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/fj-doc-quarkus-tutorial
 #
 ###
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle/src/main/docker/Dockerfile.jvm
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle/src/main/docker/Dockerfile.legacy-jar
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle/src/main/docker/Dockerfile.legacy-jar
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle/src/main/docker/Dockerfile.native
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/fj-doc-quarkus-tutorial
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle/src/main/docker/Dockerfile.native-micro
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3-gradle/src/main/docker/Dockerfile.native-micro
@@ -17,7 +17,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/fj-doc-quarkus-tutorial
 #
 ###
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3/src/main/docker/Dockerfile.jvm
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3/src/main/docker/Dockerfile.jvm
@@ -26,7 +26,8 @@
 # This scripts computes the command line to execute your Java application, and
 # includes memory/GC tuning.
 # You can configure the behavior using the following environment properties:
-# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class") - Be aware that this will override
+# the default JVM options, use `JAVA_OPTS_APPEND` to append options
 # - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
 #   in JAVA_OPTS (example: "-Dsome.property=foo")
 # - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
@@ -77,7 +78,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3/src/main/docker/Dockerfile.legacy-jar
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3/src/main/docker/Dockerfile.legacy-jar
@@ -26,7 +26,8 @@
 # This scripts computes the command line to execute your Java application, and
 # includes memory/GC tuning.
 # You can configure the behavior using the following environment properties:
-# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class") - Be aware that this will override
+# the default JVM options, use `JAVA_OPTS_APPEND` to append options
 # - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
 #   in JAVA_OPTS (example: "-Dsome.property=foo")
 # - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
@@ -77,7 +78,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3/src/main/docker/Dockerfile.native
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3/src/main/docker/Dockerfile.native
@@ -13,13 +13,15 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started
 #
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root target/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3/src/main/docker/Dockerfile.native-micro
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/quarkus-3/src/main/docker/Dockerfile.native-micro
@@ -16,13 +16,15 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started
 #
+# The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
+# To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.
 ###
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root target/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/fj-doc-native-quarkus/src/main/docker/Dockerfile.jvm
+++ b/fj-doc-native-quarkus/src/main/docker/Dockerfile.jvm
@@ -26,7 +26,8 @@
 # This scripts computes the command line to execute your Java application, and
 # includes memory/GC tuning.
 # You can configure the behavior using the following environment properties:
-# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class") - Be aware that this will override
+# the default JVM options, use `JAVA_OPTS_APPEND` to append options
 # - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
 #   in JAVA_OPTS (example: "-Dsome.property=foo")
 # - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
@@ -77,7 +78,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/fj-doc-native-quarkus/src/main/docker/Dockerfile.legacy-jar
+++ b/fj-doc-native-quarkus/src/main/docker/Dockerfile.legacy-jar
@@ -26,7 +26,8 @@
 # This scripts computes the command line to execute your Java application, and
 # includes memory/GC tuning.
 # You can configure the behavior using the following environment properties:
-# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class") - Be aware that this will override
+# the default JVM options, use `JAVA_OPTS_APPEND` to append options
 # - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
 #   in JAVA_OPTS (example: "-Dsome.property=foo")
 # - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
@@ -77,7 +78,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/fj-doc-native-quarkus/src/main/docker/Dockerfile.native
+++ b/fj-doc-native-quarkus/src/main/docker/Dockerfile.native
@@ -13,13 +13,15 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started
 #
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root target/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/fj-doc-native-quarkus/src/main/docker/Dockerfile.native-micro
+++ b/fj-doc-native-quarkus/src/main/docker/Dockerfile.native-micro
@@ -16,13 +16,15 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started
 #
+# The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
+# To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.
 ###
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root target/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/fj-doc-playground-quarkus/Dockerfile
+++ b/fj-doc-playground-quarkus/Dockerfile
@@ -11,7 +11,7 @@
 # docker image tag [image tag] fugeritorg/fj-doc-playground-quarkus:latest
 #
 # Change with any base openjdk image is preferred 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.21-1.1739376167
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 
 LABEL org.opencontainers.image.authors="Fugerit" \
       org.opencontainers.image.source="Quarkus" \


### PR DESCRIPTION
Starting from quarkus 3.19.0 ubi 9 images should be used.

See for instance pull request :
https://github.com/quarkusio/quarkus/pull/46231

Just changing the base image from quay.io/quarkus/quarkus-micro-image:2.0 to quay.io/quarkus/ubi9-quarkus-micro-image:2.0