### PR TITLE
fix: correct typo in mime type check method

### DIFF
--- a/fj-doc-val-core/src/main/java/org/fugerit/java/doc/val/core/DocValidatorFacade.java
+++ b/fj-doc-val-core/src/main/java/org/fugerit/java/doc/val/core/DocValidatorFacade.java
@@ -74,9 +74,9 @@ public class DocValidatorFacade {
 		return this.extMapValidator.get( extension );
 	}
 	
-	public boolean isMimeTypeSupprted( String mimeType ) {
-		return this.findByMimeType(mimeType) != null;
-	}
+       public boolean isMimeTypeSupported( String mimeType ) {
+               return this.findByMimeType(mimeType) != null;
+       }
 
 	public Collection<String> getSupportedMimeTypes() {
 		return Collections.unmodifiableCollection( this.mimMapValidator.keySet() );

--- a/fj-doc-val-core/src/test/java/test/org/fugerit/java/doc/core/val/TestAllValidatorFacade.java
+++ b/fj-doc-val-core/src/test/java/test/org/fugerit/java/doc/core/val/TestAllValidatorFacade.java
@@ -86,13 +86,13 @@ class TestAllValidatorFacade extends TestDocValidatorFacade {
 		Assertions.assertNull( facade.findByExtension( HelperDocValidator.FORMAT_TEST ) );
 		Assertions.assertFalse( facade.getSupportedMimeTypes().isEmpty() );
 		Assertions.assertFalse( facade.getSupportedExtensions().isEmpty() );
-		Assertions.assertFalse( facade.isMimeTypeSupprted( HelperDocValidator.MIME_TEST ) );
+               Assertions.assertFalse( facade.isMimeTypeSupported( HelperDocValidator.MIME_TEST ) );
 		Assertions.assertFalse( facade.isExtensionSupported( HelperDocValidator.FORMAT_TEST ) );
-		Assertions.assertFalse( facade.isMimeTypeSupprted( HelperDocValidator.MIME_TEST ) );
+               Assertions.assertFalse( facade.isMimeTypeSupported( HelperDocValidator.MIME_TEST ) );
 		Assertions.assertFalse( facade.isExtensionSupported( HelperDocValidator.FORMAT_TEST ) );
-		Assertions.assertFalse( facade.isMimeTypeSupprted( "aaaa" ) );
+               Assertions.assertFalse( facade.isMimeTypeSupported( "aaaa" ) );
 		Assertions.assertFalse( facade.isExtensionSupported( "bbbb/test" ) );
-		Assertions.assertTrue( facade.isMimeTypeSupprted( ImageValidator.JPG_VALIDATOR.getMimeType() ) );
+               Assertions.assertTrue( facade.isMimeTypeSupported( ImageValidator.JPG_VALIDATOR.getMimeType() ) );
 		Assertions.assertTrue( facade.isExtensionSupported( ImageValidator.FORMAT_JPG ) );
 		// test path
 		String testPath = "src/test/resources/sample/jpg_as_jpg.jpeg";


### PR DESCRIPTION
## Summary
- fix method name typo `isMimeTypeSupprted` -> `isMimeTypeSupported`
- update validator facade tests accordingly

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68534718954483328b5ce221fb6091b7