### PR TITLE
494 chore quarkus version set to 3261 across all the module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fj-doc-maven-plugin, flavour micronaut version set to 4.9.3
 - fj-doc-maven-plugin, flavour springboot-3 version set to 3.5.5
 - quarkus-version set to 3.26.1 across all the modules <https://github.com/fugerit-org/fj-doc/issues/494>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- quarkus-version set to 3.26.1 across all the modules <https://github.com/fugerit-org/fj-doc/issues/494>
+
 ## [8.16.0] - 2025-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fj-doc-maven-plugin, flavour openliberty version set to 25.0.0.8
 - fj-doc-maven-plugin, flavour micronaut version set to 4.9.3
 - fj-doc-maven-plugin, flavour springboot-3 version set to 3.5.5
 - quarkus-version set to 3.26.1 across all the modules <https://github.com/fugerit-org/fj-doc/issues/494>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fj-doc-maven-plugin, flavour springboot-3 version set to 3.5.5
 - quarkus-version set to 3.26.1 across all the modules <https://github.com/fugerit-org/fj-doc/issues/494>
 
 ## [8.16.0] - 2025-08-22

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/flavour_versions_default.properties
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/flavour_versions_default.properties
@@ -1,8 +1,8 @@
 # default flavour versions
-quarkus-3=3.25.4
-quarkus-3-gradle=3.25.4
-quarkus-3-gradle-kts=3.25.4
-quarkus-3-properties=3.25.4
+quarkus-3=3.26.1
+quarkus-3-gradle=3.26.1
+quarkus-3-gradle-kts=3.26.1
+quarkus-3-properties=3.26.1
 quarkus-2=2.16.12.Final
 micronaut-4=4.9.1
 springboot-3=3.5.3

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/flavour_versions_default.properties
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/flavour_versions_default.properties
@@ -5,5 +5,5 @@ quarkus-3-gradle-kts=3.26.1
 quarkus-3-properties=3.26.1
 quarkus-2=2.16.12.Final
 micronaut-4=4.9.1
-springboot-3=3.5.3
+springboot-3=3.5.5
 openliberty=25.0.0.7

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/flavour_versions_default.properties
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/flavour_versions_default.properties
@@ -4,6 +4,6 @@ quarkus-3-gradle=3.26.1
 quarkus-3-gradle-kts=3.26.1
 quarkus-3-properties=3.26.1
 quarkus-2=2.16.12.Final
-micronaut-4=4.9.1
+micronaut-4=4.9.3
 springboot-3=3.5.5
 openliberty=25.0.0.7

--- a/fj-doc-maven-plugin/src/main/resources/config/flavour/flavour_versions_default.properties
+++ b/fj-doc-maven-plugin/src/main/resources/config/flavour/flavour_versions_default.properties
@@ -6,4 +6,4 @@ quarkus-3-properties=3.26.1
 quarkus-2=2.16.12.Final
 micronaut-4=4.9.3
 springboot-3=3.5.5
-openliberty=25.0.0.7
+openliberty=25.0.0.8

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 	    <jajarta-jaxb-impl-version>4.0.5</jajarta-jaxb-impl-version>
 	    <poi5-version>${poi-version}</poi5-version>
 		<kotlin.version>2.2.10</kotlin.version>
-		<quarkus-version>3.26.0</quarkus-version>
+		<quarkus-version>3.26.1</quarkus-version>
 	</properties>
 
 	<licenses>


### PR DESCRIPTION
Additionally updated versions for spring boot, micronaut and liberty