### PR TITLE
519 bug orgfugeritjavadocbaseconfigdoctypehandlerxml renders the source document in the source format ie json or yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- type handlers for XML (DocTypeHandlerCoreXML and DocTypeHandlerCoreXMLUTF8)
+- type handlers for JSON (DocTypeHandlerCoreJSON and DocTypeHandlerCoreJSONUTF8)
+- - type handlers for JSON (DocTypeHandlerCoreYAML and DocTypeHandlerCoreYAMLUTF8)
+
 ## [8.16.5] - 2025-09-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - type handlers for XML (DocTypeHandlerCoreXML and DocTypeHandlerCoreXMLUTF8)
 - type handlers for JSON (DocTypeHandlerCoreJSON and DocTypeHandlerCoreJSONUTF8)
-- - type handlers for JSON (DocTypeHandlerCoreYAML and DocTypeHandlerCoreYAMLUTF8)
+- type handlers for JSON (DocTypeHandlerCoreYAML and DocTypeHandlerCoreYAMLUTF8)
+
+### Fixed
+
+- org.fugerit.java.doc.base.config.DocTypeHandlerXML renders the source document in the source format (i.e. JSON or YAML) <https://github.com/fugerit-org/fj-doc/issues/519>
 
 ## [8.16.5] - 2025-09-29
 

--- a/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/DocJsonToXml.java
+++ b/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/DocJsonToXml.java
@@ -8,6 +8,7 @@ import org.fugerit.java.core.lang.helpers.StringUtils;
 import org.fugerit.java.core.xml.dom.DOMIO;
 import org.fugerit.java.doc.base.config.DocVersion;
 import org.fugerit.java.doc.base.facade.DocFacade;
+import org.fugerit.java.doc.base.parser.DocConvert;
 import org.fugerit.java.doc.base.parser.DocParserContext;
 import org.fugerit.java.xml2json.XmlToJsonHandler;
 import org.w3c.dom.Element;
@@ -15,7 +16,7 @@ import org.w3c.dom.Element;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class DocJsonToXml {
+public class DocJsonToXml implements DocConvert {
 	
 	private XmlToJsonHandler handler;
 	
@@ -71,5 +72,10 @@ public class DocJsonToXml {
 		this.setIfNotFound(root, ATT_XSD_LOC, DocParserContext.createXsdVersionXmlns( xsdVersion ));
 		return root;
 	}
-	
+
+	@Override
+	public void convert(Reader from, Writer to) throws ConfigException {
+		this.writerAsXml(from, to);
+	}
+
 }

--- a/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/DocJsonToXml.java
+++ b/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/DocJsonToXml.java
@@ -18,10 +18,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DocJsonToXml implements DocConvert {
 	
-	private XmlToJsonHandler handler;
+	private final XmlToJsonHandler handler;
 	
 	public DocJsonToXml() {
-		this( new ObjectMapper() );
+		this( JsonConstants.getDefaultMapper() );
 	}
 	
 	public DocJsonToXml(ObjectMapper mapper) {

--- a/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/DocXmlToJson.java
+++ b/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/DocXmlToJson.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DocXmlToJson implements DocConvert {
 	
-	private XmlToJsonHandler handler;
+	private final XmlToJsonHandler handler;
 	
 	public DocXmlToJson() {
 		this( JsonConstants.getDefaultMapper() );

--- a/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/DocXmlToJson.java
+++ b/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/DocXmlToJson.java
@@ -18,7 +18,7 @@ public class DocXmlToJson implements DocConvert {
 	private XmlToJsonHandler handler;
 	
 	public DocXmlToJson() {
-		this( new ObjectMapper() );
+		this( JsonConstants.getDefaultMapper() );
 	}
 	
 	public DocXmlToJson(ObjectMapper mapper) {

--- a/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/DocXmlToJson.java
+++ b/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/DocXmlToJson.java
@@ -1,9 +1,11 @@
 package org.fugerit.java.doc.json.parse;
 
 import java.io.Reader;
+import java.io.Writer;
 
 import org.fugerit.java.core.cfg.ConfigException;
 import org.fugerit.java.core.xml.dom.DOMIO;
+import org.fugerit.java.doc.base.parser.DocConvert;
 import org.fugerit.java.xml2json.XmlToJsonHandler;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -11,9 +13,9 @@ import org.w3c.dom.Element;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class DocXmlToJson {
+public class DocXmlToJson implements DocConvert {
 	
-	private XmlToJsonHandler hanlder;
+	private XmlToJsonHandler handler;
 	
 	public DocXmlToJson() {
 		this( new ObjectMapper() );
@@ -25,7 +27,7 @@ public class DocXmlToJson {
 	
 	public DocXmlToJson(XmlToJsonHandler handler) {
 		super();
-		this.hanlder = handler;
+		this.handler = handler;
 	}
 	
 	public JsonNode convertToJsonNode( Reader xml ) throws ConfigException {
@@ -37,7 +39,11 @@ public class DocXmlToJson {
 	}
 	
 	public JsonNode convert( Element root ) throws ConfigException {
-		return ConfigException.get( () -> this.hanlder.convert( root ) );
+		return ConfigException.get( () -> this.handler.convert( root ) );
 	}
-	
+
+	@Override
+	public void convert(Reader from, Writer to) throws ConfigException {
+		ConfigException.apply( () -> this.handler.getMapper().writerWithDefaultPrettyPrinter().writeValue( to, this.convertToJsonNode( from ) ) );
+	}
 }

--- a/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/JsonConstants.java
+++ b/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/parse/JsonConstants.java
@@ -1,0 +1,15 @@
+package org.fugerit.java.doc.json.parse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonConstants {
+
+    private JsonConstants() {}
+
+    private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
+
+    public static ObjectMapper getDefaultMapper() {
+        return DEFAULT_MAPPER;
+    }
+
+}

--- a/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/typehandler/DocTypeHandlerCoreJSON.java
+++ b/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/typehandler/DocTypeHandlerCoreJSON.java
@@ -18,7 +18,7 @@ public class DocTypeHandlerCoreJSON extends DocTypeHandlerDefault {
 
     public static final DocTypeHandler HANDLER_UTF8 = new DocTypeHandlerCoreJSON( StandardCharsets.UTF_8 );
 
-    public static final String TYPE = DocConfig.TYPE_XML;
+    public static final String TYPE = DocConfig.TYPE_JSON;
 
     public static final String MODULE = "doc-core";
 

--- a/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/typehandler/DocTypeHandlerCoreJSON.java
+++ b/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/typehandler/DocTypeHandlerCoreJSON.java
@@ -1,0 +1,39 @@
+package org.fugerit.java.doc.json.typehandler;
+
+import org.fugerit.java.doc.base.config.*;
+import org.fugerit.java.doc.base.facade.DocFacadeSource;
+
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class DocTypeHandlerCoreJSON extends DocTypeHandlerDefault {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = -50249858785381015L;
+
+    public static final DocTypeHandler HANDLER = new DocTypeHandlerCoreJSON();
+
+    public static final DocTypeHandler HANDLER_UTF8 = new DocTypeHandlerCoreJSON( StandardCharsets.UTF_8 );
+
+    public static final String TYPE = DocConfig.TYPE_XML;
+
+    public static final String MODULE = "doc-core";
+
+    public DocTypeHandlerCoreJSON(Charset charset ) {
+        super( TYPE, MODULE, null, charset );
+    }
+
+    public DocTypeHandlerCoreJSON() {
+        super( TYPE, MODULE );
+    }
+
+    @Override
+    public void handle(DocInput docInput, DocOutput docOutput) throws Exception {
+        DocFacadeSource.getInstance().convert( docInput.getReader(),
+                docInput.getSource(), new OutputStreamWriter( docOutput.getOs() ), DocFacadeSource.SOURCE_TYPE_JSON );
+    }
+
+}

--- a/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/typehandler/DocTypeHandlerCoreJSONUTF8.java
+++ b/fj-doc-base-json/src/main/java/org/fugerit/java/doc/json/typehandler/DocTypeHandlerCoreJSONUTF8.java
@@ -1,0 +1,16 @@
+package org.fugerit.java.doc.json.typehandler;
+
+import org.fugerit.java.doc.base.config.DocTypeHandler;
+import org.fugerit.java.doc.base.config.DocTypeHandlerDecorator;
+
+public class DocTypeHandlerCoreJSONUTF8 extends DocTypeHandlerDecorator {
+
+    private static final long serialVersionUID = -8512951518109L;
+
+    public static final DocTypeHandler HANDLER = new DocTypeHandlerCoreJSONUTF8();
+
+    public DocTypeHandlerCoreJSONUTF8() {
+        super( DocTypeHandlerCoreJSON.HANDLER_UTF8 );
+    }
+
+}

--- a/fj-doc-base-json/src/test/java/test/org/fugerit/java/doc/json/parse/TestDocJsonToXml.java
+++ b/fj-doc-base-json/src/test/java/test/org/fugerit/java/doc/json/parse/TestDocJsonToXml.java
@@ -46,7 +46,7 @@ class TestDocJsonToXml {
 			try ( InputStreamReader reader = new InputStreamReader( ClassHelper.loadFromDefaultClassLoader( "sample/doc_test_01.json" ) );
 					StringWriter writer = new StringWriter() ) {
 				DocJsonToXml converter = new DocJsonToXml();
-				converter.writerAsXml(reader, writer);
+				converter.convert(reader, writer);
 				return writer.toString();
 			}
 		} ) );

--- a/fj-doc-base-json/src/test/java/test/org/fugerit/java/doc/json/typehandler/TestJsonHandlers.java
+++ b/fj-doc-base-json/src/test/java/test/org/fugerit/java/doc/json/typehandler/TestJsonHandlers.java
@@ -1,0 +1,32 @@
+package test.org.fugerit.java.doc.json.typehandler;
+
+import org.fugerit.java.doc.base.config.DocInput;
+import org.fugerit.java.doc.base.config.DocOutput;
+import org.fugerit.java.doc.base.config.DocTypeHandler;
+import org.fugerit.java.doc.json.typehandler.DocTypeHandlerCoreJSONUTF8;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+
+class TestJsonHandlers {
+
+    private static final String INPUT_DOC = "<doc/>";
+
+    private static final String OUTPUT_DOC = "{\n" +
+            "  \"_t\" : \"doc\"\n" +
+            "}";
+
+    @Test
+    void testHandler() throws Exception {
+        DocTypeHandler handler = DocTypeHandlerCoreJSONUTF8.HANDLER;
+        try (StringReader from = new StringReader(INPUT_DOC);
+             ByteArrayOutputStream os = new ByteArrayOutputStream();
+        ) {
+            handler.handle(DocInput.newInput( handler.getType(), from ), DocOutput.newOutput(os));
+            Assertions.assertEquals( OUTPUT_DOC, os.toString() );
+        }
+    }
+
+}

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocJsonToYaml.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocJsonToYaml.java
@@ -1,10 +1,11 @@
 package org.fugerit.java.doc.yaml.parse;
 
+import org.fugerit.java.doc.json.parse.JsonConstants;
 
 public class DocJsonToYaml extends DocYamlToJson {
 
     public DocJsonToYaml() {
-        super( JSON_MAPPER, YAML_MAPPER );
+        super(JsonConstants.getDefaultMapper(), YamlConstants.getDefaultMapper());
     }
 
 }

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocJsonToYaml.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocJsonToYaml.java
@@ -1,0 +1,10 @@
+package org.fugerit.java.doc.yaml.parse;
+
+
+public class DocJsonToYaml extends DocYamlToJson {
+
+    public DocJsonToYaml() {
+        super( JSON_MAPPER, YAML_MAPPER );
+    }
+
+}

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocXmlToYaml.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocXmlToYaml.java
@@ -1,15 +1,11 @@
 package org.fugerit.java.doc.yaml.parse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.fugerit.java.doc.json.parse.DocXmlToJson;
 
 public class DocXmlToYaml extends DocXmlToJson {
 
-    private static final ObjectMapper YAML_MAPPER = new YAMLMapper();
-
     public DocXmlToYaml() {
-        super(YAML_MAPPER);
+        super( YamlConstants.getDefaultMapper() );
     }
 
 }

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocXmlToYaml.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocXmlToYaml.java
@@ -1,0 +1,15 @@
+package org.fugerit.java.doc.yaml.parse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.fugerit.java.doc.json.parse.DocXmlToJson;
+
+public class DocXmlToYaml extends DocXmlToJson {
+
+    private static final ObjectMapper YAML_MAPPER = new YAMLMapper();
+
+    public DocXmlToYaml() {
+        super(YAML_MAPPER);
+    }
+
+}

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlParser.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlParser.java
@@ -4,8 +4,6 @@ import org.fugerit.java.doc.base.facade.DocFacadeSource;
 import org.fugerit.java.doc.json.parse.DocJsonParser;
 import org.fugerit.java.xml2json.XmlToJsonHandler;
 
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-
 public class DocYamlParser extends DocJsonParser {
 	
 	public DocYamlParser( XmlToJsonHandler handler ) {
@@ -13,7 +11,7 @@ public class DocYamlParser extends DocJsonParser {
 	}
 	
 	public DocYamlParser() {
-		this( new XmlToJsonHandler( new YAMLMapper() ) );
+		this( new XmlToJsonHandler( YamlConstants.getDefaultMapper() ) );
 	}
 
 }

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlToJson.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlToJson.java
@@ -1,0 +1,40 @@
+package org.fugerit.java.doc.yaml.parse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.fugerit.java.core.cfg.ConfigException;
+import org.fugerit.java.core.io.StreamIO;
+import org.fugerit.java.doc.base.parser.DocConvert;
+
+import java.io.Reader;
+import java.io.Writer;
+
+public class DocYamlToJson implements DocConvert {
+
+    protected static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    protected static final ObjectMapper YAML_MAPPER = new YAMLMapper();
+
+    private ObjectMapper mapperFrom;
+
+    private ObjectMapper mapperTo;
+
+    public DocYamlToJson() {
+        this( YAML_MAPPER, JSON_MAPPER );
+    }
+
+    public DocYamlToJson(ObjectMapper mapperFrom, ObjectMapper mapperTo) {
+        this.mapperFrom = mapperFrom;
+        this.mapperTo = mapperTo;
+    }
+
+    @Override
+    public void convert(Reader from, Writer to) throws ConfigException {
+        ConfigException.apply( () -> {
+            JsonNode node = this.mapperFrom.readTree( from );
+            this.mapperTo.writerWithDefaultPrettyPrinter().writeValue(to, node);
+        } );
+    }
+
+}

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlToJson.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlToJson.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.fugerit.java.core.cfg.ConfigException;
-import org.fugerit.java.core.io.StreamIO;
 import org.fugerit.java.doc.base.parser.DocConvert;
 
 import java.io.Reader;

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlToJson.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlToJson.java
@@ -2,25 +2,21 @@ package org.fugerit.java.doc.yaml.parse;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.fugerit.java.core.cfg.ConfigException;
 import org.fugerit.java.doc.base.parser.DocConvert;
+import org.fugerit.java.doc.json.parse.JsonConstants;
 
 import java.io.Reader;
 import java.io.Writer;
 
 public class DocYamlToJson implements DocConvert {
 
-    protected static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-
-    protected static final ObjectMapper YAML_MAPPER = new YAMLMapper();
-
     private ObjectMapper mapperFrom;
 
     private ObjectMapper mapperTo;
 
     public DocYamlToJson() {
-        this( YAML_MAPPER, JSON_MAPPER );
+        this( YamlConstants.getDefaultMapper(), JsonConstants.getDefaultMapper() );
     }
 
     public DocYamlToJson(ObjectMapper mapperFrom, ObjectMapper mapperTo) {

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlToXml.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlToXml.java
@@ -3,7 +3,6 @@ package org.fugerit.java.doc.yaml.parse;
 import org.fugerit.java.doc.json.parse.DocJsonToXml;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class DocYamlToXml extends DocJsonToXml {
 

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlToXml.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/DocYamlToXml.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 public class DocYamlToXml extends DocJsonToXml {
 
 	public DocYamlToXml() {
-		super( new ObjectMapper( new YAMLFactory() ) );
+		super( YamlConstants.getDefaultMapper() );
 	}
 
 	public DocYamlToXml(ObjectMapper mapper) {

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/YamlConstants.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/parse/YamlConstants.java
@@ -1,0 +1,18 @@
+package org.fugerit.java.doc.yaml.parse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+public class YamlConstants {
+
+    private YamlConstants() {}
+
+    private static final ObjectMapper DEFAULT_MAPPER = new YAMLMapper();
+
+    public static ObjectMapper getDefaultMapper() {
+        return DEFAULT_MAPPER;
+    }
+
+}
+
+

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/typehandler/DocTypeHandlerCoreYAML.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/typehandler/DocTypeHandlerCoreYAML.java
@@ -1,0 +1,39 @@
+package org.fugerit.java.doc.yaml.typehandler;
+
+import org.fugerit.java.doc.base.config.*;
+import org.fugerit.java.doc.base.facade.DocFacadeSource;
+
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class DocTypeHandlerCoreYAML extends DocTypeHandlerDefault {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = -50249858785381015L;
+
+    public static final DocTypeHandler HANDLER = new DocTypeHandlerCoreYAML();
+
+    public static final DocTypeHandler HANDLER_UTF8 = new DocTypeHandlerCoreYAML( StandardCharsets.UTF_8 );
+
+    public static final String TYPE = DocConfig.TYPE_YAML;
+
+    public static final String MODULE = "doc-core";
+
+    public DocTypeHandlerCoreYAML(Charset charset ) {
+        super( TYPE, MODULE, null, charset );
+    }
+
+    public DocTypeHandlerCoreYAML() {
+        super( TYPE, MODULE );
+    }
+
+    @Override
+    public void handle(DocInput docInput, DocOutput docOutput) throws Exception {
+        DocFacadeSource.getInstance().convert( docInput.getReader(),
+                docInput.getSource(), new OutputStreamWriter( docOutput.getOs() ), DocFacadeSource.SOURCE_TYPE_YAML );
+    }
+
+}

--- a/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/typehandler/DocTypeHandlerCoreYAMLUTF8.java
+++ b/fj-doc-base-yaml/src/main/java/org/fugerit/java/doc/yaml/typehandler/DocTypeHandlerCoreYAMLUTF8.java
@@ -1,0 +1,16 @@
+package org.fugerit.java.doc.yaml.typehandler;
+
+import org.fugerit.java.doc.base.config.DocTypeHandler;
+import org.fugerit.java.doc.base.config.DocTypeHandlerDecorator;
+
+public class DocTypeHandlerCoreYAMLUTF8 extends DocTypeHandlerDecorator {
+
+    private static final long serialVersionUID = -8512962958109L;
+
+    public static final DocTypeHandler HANDLER = new DocTypeHandlerCoreYAMLUTF8();
+
+    public DocTypeHandlerCoreYAMLUTF8() {
+        super( DocTypeHandlerCoreYAML.HANDLER_UTF8 );
+    }
+
+}

--- a/fj-doc-base-yaml/src/test/java/test/org/fugerit/java/doc/DocFacadeSourceConvertTest.java
+++ b/fj-doc-base-yaml/src/test/java/test/org/fugerit/java/doc/DocFacadeSourceConvertTest.java
@@ -1,0 +1,56 @@
+package test.org.fugerit.java.doc;
+
+import lombok.extern.slf4j.Slf4j;
+import org.fugerit.java.core.function.SafeFunction;
+import org.fugerit.java.doc.base.facade.DocFacadeSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+class DocFacadeSourceConvertTest {
+
+    private static final String TEST_XML_PATH = "src/test/resources/convert/doc_test_01.xml";
+    private static final String TEST_JSON_PATH = "src/test/resources/convert/doc_test_01.json";
+    private static final String TEST_YAML_PATH = "src/test/resources/convert/doc_test_01.yaml";
+
+    private static final Map<Integer, String> MAP_SAMPLES = new HashMap<>();
+    static {
+        MAP_SAMPLES.put( DocFacadeSource.SOURCE_TYPE_XML, TEST_XML_PATH );
+        MAP_SAMPLES.put( DocFacadeSource.SOURCE_TYPE_JSON, TEST_JSON_PATH );
+        MAP_SAMPLES.put( DocFacadeSource.SOURCE_TYPE_YAML, TEST_YAML_PATH );
+    }
+
+    @Test
+    void testConvertFormats() {
+        List<Integer> sourceTypes = Arrays.asList( DocFacadeSource.SOURCE_TYPE_XML, DocFacadeSource.SOURCE_TYPE_JSON, DocFacadeSource.SOURCE_TYPE_YAML );
+        for ( Integer fromSourceType : sourceTypes ) {
+            for ( Integer toSourceType : sourceTypes ) {
+                if ( fromSourceType != toSourceType  ) {
+                    String testPath = MAP_SAMPLES.get( fromSourceType );
+                    SafeFunction.apply( () -> {
+                        try (Reader from = new FileReader( new File( testPath ) );
+                             Writer to = new StringWriter() ) {
+                            log.info( "Convert from {} to {}", fromSourceType, toSourceType );
+                            DocFacadeSource.getInstance().convert( from, fromSourceType, to, toSourceType );
+                            log.info( "Conversion result : \n{}", to );
+                            if ( toSourceType == DocFacadeSource.SOURCE_TYPE_XML ) {
+                                Assertions.assertTrue( to.toString().startsWith( "<" ) );
+                            } else if ( toSourceType == DocFacadeSource.SOURCE_TYPE_JSON ) {
+                                Assertions.assertTrue( to.toString().startsWith( "{" ) );
+                            } else if ( toSourceType == DocFacadeSource.SOURCE_TYPE_YAML ) {
+                                Assertions.assertTrue( to.toString().startsWith( "---" ) );
+                            }
+                        }
+                    } );
+                }
+            }
+        }
+    }
+
+}

--- a/fj-doc-base-yaml/src/test/java/test/org/fugerit/java/doc/DocFacadeSourceConvertTest.java
+++ b/fj-doc-base-yaml/src/test/java/test/org/fugerit/java/doc/DocFacadeSourceConvertTest.java
@@ -29,9 +29,10 @@ class DocFacadeSourceConvertTest {
     @Test
     void testConvertFormats() {
         List<Integer> sourceTypes = Arrays.asList( DocFacadeSource.SOURCE_TYPE_XML, DocFacadeSource.SOURCE_TYPE_JSON, DocFacadeSource.SOURCE_TYPE_YAML );
+        int count = 0;
         for ( Integer fromSourceType : sourceTypes ) {
             for ( Integer toSourceType : sourceTypes ) {
-                if ( fromSourceType != toSourceType  ) {
+                if ( !fromSourceType.equals( toSourceType )  ) {
                     String testPath = MAP_SAMPLES.get( fromSourceType );
                     SafeFunction.apply( () -> {
                         try (Reader from = new FileReader( new File( testPath ) );
@@ -48,8 +49,10 @@ class DocFacadeSourceConvertTest {
                             }
                         }
                     } );
+                    count++;
                 }
             }
+            Assertions.assertTrue( count > 0 );
         }
     }
 

--- a/fj-doc-base-yaml/src/test/java/test/org/fugerit/java/doc/yaml/parse/TestYamlDocumentProcessing.java
+++ b/fj-doc-base-yaml/src/test/java/test/org/fugerit/java/doc/yaml/parse/TestYamlDocumentProcessing.java
@@ -4,7 +4,6 @@ import org.fugerit.java.core.function.SafeFunction;
 import org.fugerit.java.core.lang.helpers.ClassHelper;
 import org.fugerit.java.doc.base.config.*;
 import org.fugerit.java.doc.base.facade.DocFacadeSource;
-import org.fugerit.java.doc.base.model.DocBase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/fj-doc-base-yaml/src/test/java/test/org/fugerit/java/doc/yaml/parse/TestYamlDocumentProcessing.java
+++ b/fj-doc-base-yaml/src/test/java/test/org/fugerit/java/doc/yaml/parse/TestYamlDocumentProcessing.java
@@ -1,0 +1,35 @@
+package test.org.fugerit.java.doc.yaml.parse;
+
+import org.fugerit.java.core.function.SafeFunction;
+import org.fugerit.java.core.lang.helpers.ClassHelper;
+import org.fugerit.java.doc.base.config.*;
+import org.fugerit.java.doc.base.facade.DocFacadeSource;
+import org.fugerit.java.doc.base.model.DocBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+class TestYamlDocumentProcessing {
+
+	private static final Logger logger = LoggerFactory.getLogger( TestYamlDocumentProcessing.class );
+
+	@Test
+	void testGenerateXML() {
+		Assertions.assertNotNull( SafeFunction.get( () -> {
+				try ( InputStreamReader reader = new InputStreamReader(
+						ClassHelper.loadFromDefaultClassLoader( "sample/doc_test_01.yaml" ) );
+					  ByteArrayOutputStream buffer = new ByteArrayOutputStream() ) {
+					DocInput docInput = DocInput.newInput( DocConfig.TYPE_XML, reader, DocFacadeSource.SOURCE_TYPE_YAML );
+					DocTypeHandlerXMLUTF8.HANDLER.handle( docInput, DocOutput.newOutput( buffer ) );
+					logger.info( "xml output -> {}", new String( buffer.toByteArray(), StandardCharsets.UTF_8 ) );
+					return buffer.toByteArray();
+				}
+			} )
+		);
+	}
+	
+}

--- a/fj-doc-base-yaml/src/test/java/test/org/fugerit/java/doc/yaml/typehandler/TestYamlHandlers.java
+++ b/fj-doc-base-yaml/src/test/java/test/org/fugerit/java/doc/yaml/typehandler/TestYamlHandlers.java
@@ -1,0 +1,31 @@
+package test.org.fugerit.java.doc.yaml.typehandler;
+
+import org.fugerit.java.doc.base.config.DocInput;
+import org.fugerit.java.doc.base.config.DocOutput;
+import org.fugerit.java.doc.base.config.DocTypeHandler;
+import org.fugerit.java.doc.yaml.typehandler.DocTypeHandlerCoreYAMLUTF8;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+
+class TestYamlHandlers {
+
+    private static final String INPUT_DOC = "<doc/>";
+
+    private static final String OUTPUT_DOC = "---\n" +
+            "_t: \"doc\"\n";
+
+    @Test
+    void testHandler() throws Exception {
+        DocTypeHandler handler = DocTypeHandlerCoreYAMLUTF8.HANDLER;
+        try (StringReader from = new StringReader(INPUT_DOC);
+             ByteArrayOutputStream os = new ByteArrayOutputStream();
+        ) {
+            handler.handle(DocInput.newInput( handler.getType(), from ), DocOutput.newOutput(os));
+            Assertions.assertEquals( OUTPUT_DOC, os.toString() );
+        }
+    }
+
+}

--- a/fj-doc-base-yaml/src/test/resources/convert/doc_test_01.json
+++ b/fj-doc-base-yaml/src/test/resources/convert/doc_test_01.json
@@ -1,0 +1,132 @@
+{
+  "xmlns:xsi" : "http://www.w3.org/2001/XMLSchema-instance",
+  "xsi:schemaLocation" : "http://javacoredoc.fugerit.org https://www.fugerit.org/data/java/doc/xsd/doc-2-1.xsd",
+  "xmlns" : "http://javacoredoc.fugerit.org",
+  "_t" : "doc",
+  "_e" : [ {
+    "_t" : "metadata",
+    "_e" : [ {
+      "name" : "margins",
+      "_t" : "info",
+      "_v" : "10;10;10;30"
+    }, {
+      "name" : "excel-table-id",
+      "_t" : "info",
+      "_v" : "excel-table=print"
+    }, {
+      "name" : "excel-width-multiplier",
+      "_t" : "info",
+      "_v" : "450"
+    }, {
+      "_t" : "footer-ext",
+      "_e" : [ {
+        "align" : "center",
+        "_t" : "para",
+        "_v" : "Page ${currentPage}"
+      } ]
+    } ]
+  }, {
+    "_t" : "body",
+    "_e" : [ {
+      "_t" : "phrase",
+      "_v" : "Test phrase 01"
+    }, {
+      "_t" : "phrase",
+      "_v" : "Test phrase 02"
+    }, {
+      "_t" : "phrase",
+      "_v" : "Test phrase 03"
+    }, {
+      "_t" : "phrase",
+      "_v" : "Test phrase 04"
+    }, {
+      "url" : "cl://test/img_test_red.png",
+      "scaling" : "100",
+      "_t" : "image"
+    }, {
+      "url" : "cl://test/img_test_green.png",
+      "scaling" : "50",
+      "_t" : "image"
+    }, {
+      "url" : "cl://test/img_test_blue.png",
+      "scaling" : "25",
+      "_t" : "image"
+    }, {
+      "columns" : "3",
+      "width" : "100",
+      "colwidths" : "30;30;40",
+      "padding" : "2",
+      "id" : "excel-table",
+      "_t" : "table",
+      "_e" : [ {
+        "_t" : "row",
+        "_e" : [ {
+          "border-color" : "#000000",
+          "border-width" : "1",
+          "align" : "center",
+          "_t" : "cell",
+          "_e" : [ {
+            "_t" : "para",
+            "_v" : "Name"
+          } ]
+        }, {
+          "align" : "center",
+          "_t" : "cell",
+          "_e" : [ {
+            "_t" : "para",
+            "_v" : "Surname"
+          } ]
+        }, {
+          "align" : "center",
+          "_t" : "cell",
+          "_e" : [ {
+            "_t" : "para",
+            "_v" : "Title"
+          } ]
+        } ]
+      }, {
+        "_t" : "row",
+        "_e" : [ {
+          "_t" : "cell",
+          "_e" : [ {
+            "_t" : "para",
+            "_v" : "Luthien"
+          } ]
+        }, {
+          "_t" : "cell",
+          "_e" : [ {
+            "_t" : "para",
+            "_v" : "Tinuviel"
+          } ]
+        }, {
+          "_t" : "cell",
+          "_e" : [ {
+            "_t" : "para",
+            "_v" : "Queen"
+          } ]
+        } ]
+      }, {
+        "_t" : "row",
+        "_e" : [ {
+          "_t" : "cell",
+          "_e" : [ {
+            "_t" : "para",
+            "_v" : "Thorin"
+          } ]
+        }, {
+          "_t" : "cell",
+          "_e" : [ {
+            "_t" : "para",
+            "_v" : "Oakshield"
+          } ]
+        }, {
+          "_t" : "cell",
+          "_e" : [ {
+            "_t" : "para",
+            "_v" : "King"
+          } ]
+        } ]
+      } ]
+    } ]
+  } ]
+}

--- a/fj-doc-base-yaml/src/test/resources/convert/doc_test_01.xml
+++ b/fj-doc-base-yaml/src/test/resources/convert/doc_test_01.xml
@@ -1,0 +1,56 @@
+<doc xmlns="http://javacoredoc.fugerit.org" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://javacoredoc.fugerit.org https://www.fugerit.org/data/java/doc/xsd/doc-2-1.xsd">
+  <metadata>
+    <info name="margins">10;10;10;30</info>
+    <info name="excel-table-id">excel-table=print</info>
+    <info name="excel-width-multiplier">450</info>
+    <footer-ext>
+      <para align="center">Page ${currentPage}</para>
+    </footer-ext>
+  </metadata>
+  <body>
+    <phrase>Test phrase 01</phrase>
+    <phrase>Test phrase 02</phrase>
+    <phrase>Test phrase 03</phrase>
+    <phrase>Test phrase 04</phrase>
+    <image scaling="100" url="cl://test/img_test_red.png"/>
+    <image scaling="50" url="cl://test/img_test_green.png"/>
+    <image scaling="25" url="cl://test/img_test_blue.png"/>
+    <table columns="3" colwidths="30;30;40" id="excel-table" padding="2" width="100">
+      <row>
+        <cell align="center" border-color="#000000" border-width="1">
+          <para>Name</para>
+        </cell>
+        <cell align="center">
+          <para>Surname</para>
+        </cell>
+        <cell align="center">
+          <para>Title</para>
+        </cell>
+      </row>
+      <row>
+        <cell>
+          <para>Luthien</para>
+        </cell>
+        <cell>
+          <para>Tinuviel</para>
+        </cell>
+        <cell>
+          <para>Queen</para>
+        </cell>
+      </row>
+      <row>
+        <cell>
+          <para>Thorin</para>
+        </cell>
+        <cell>
+          <para>Oakshield</para>
+        </cell>
+        <cell>
+          <para>King</para>
+        </cell>
+      </row>
+    </table>
+  </body>
+</doc>

--- a/fj-doc-base-yaml/src/test/resources/convert/doc_test_01.yaml
+++ b/fj-doc-base-yaml/src/test/resources/convert/doc_test_01.yaml
@@ -1,0 +1,95 @@
+---
+xmlns:xsi: "http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation: "http://javacoredoc.fugerit.org https://www.fugerit.org/data/java/doc/xsd/doc-2-1.xsd"
+xmlns: "http://javacoredoc.fugerit.org"
+_t: "doc"
+_e:
+- _t: "metadata"
+  _e:
+  - name: "margins"
+    _t: "info"
+    _v: "10;10;10;30"
+  - name: "excel-table-id"
+    _t: "info"
+    _v: "excel-table=print"
+  - name: "excel-width-multiplier"
+    _t: "info"
+    _v: "450"
+  - _t: "footer-ext"
+    _e:
+    - align: "center"
+      _t: "para"
+      _v: "Page ${currentPage}"
+- _t: "body"
+  _e:
+  - _t: "phrase"
+    _v: "Test phrase 01"
+  - _t: "phrase"
+    _v: "Test phrase 02"
+  - _t: "phrase"
+    _v: "Test phrase 03"
+  - _t: "phrase"
+    _v: "Test phrase 04"
+  - url: "cl://test/img_test_red.png"
+    scaling: "100"
+    _t: "image"
+  - url: "cl://test/img_test_green.png"
+    scaling: "50"
+    _t: "image"
+  - url: "cl://test/img_test_blue.png"
+    scaling: "25"
+    _t: "image"
+  - columns: "3"
+    width: "100"
+    colwidths: "30;30;40"
+    padding: "2"
+    id: "excel-table"
+    _t: "table"
+    _e:
+    - _t: "row"
+      _e:
+      - border-color: "#000000"
+        border-width: "1"
+        align: "center"
+        _t: "cell"
+        _e:
+        - _t: "para"
+          _v: "Name"
+      - align: "center"
+        _t: "cell"
+        _e:
+        - _t: "para"
+          _v: "Surname"
+      - align: "center"
+        _t: "cell"
+        _e:
+        - _t: "para"
+          _v: "Title"
+    - _t: "row"
+      _e:
+      - _t: "cell"
+        _e:
+        - _t: "para"
+          _v: "Luthien"
+      - _t: "cell"
+        _e:
+        - _t: "para"
+          _v: "Tinuviel"
+      - _t: "cell"
+        _e:
+        - _t: "para"
+          _v: "Queen"
+    - _t: "row"
+      _e:
+      - _t: "cell"
+        _e:
+        - _t: "para"
+          _v: "Thorin"
+      - _t: "cell"
+        _e:
+        - _t: "para"
+          _v: "Oakshield"
+      - _t: "cell"
+        _e:
+        - _t: "para"
+          _v: "King"

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/config/DocConfig.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/config/DocConfig.java
@@ -13,9 +13,15 @@ public class DocConfig {
     public static final String FUGERIT_VENUS_DOC = "Venus Fugerit Doc";
 
 	public static final String VERSION = " FUGERIT DOC Version 2.1 (2023-08-19) ";
-	
+
+	public static final String TYPE_TXT = "txt";
+
 	public static final String TYPE_XML = "xml";
-	
+
+	public static final String TYPE_JSON = "json";
+
+	public static final String TYPE_YAML = "yaml";
+
 	public static final String TYPE_PDF = "pdf";
 	public static final String FORMAT_PDF_A_1A = "PDF/A-1a";
 	public static final String FORMAT_PDF_A_1B = "PDF/A-1b";

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/config/DocTypeHandlerXML.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/config/DocTypeHandlerXML.java
@@ -6,6 +6,11 @@ import java.nio.charset.StandardCharsets;
 
 import org.fugerit.java.core.io.StreamIO;
 
+/**
+ * This type handler will be substituted by DocTypeHandlerCoreSource.
+ *
+ * @see org.fugerit.java.doc.base.typehandler.core.DocTypeHandlerCoreSource
+ */
 public class DocTypeHandlerXML extends DocTypeHandlerDefault {
 
 	/**

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/facade/DocFacadeSource.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/facade/DocFacadeSource.java
@@ -2,6 +2,7 @@ package org.fugerit.java.doc.base.facade;
 
 import java.io.Reader;
 import java.io.StringReader;
+import java.io.Writer;
 import java.util.Properties;
 
 import org.fugerit.java.core.cfg.ConfigRuntimeException;
@@ -12,6 +13,7 @@ import org.fugerit.java.doc.base.config.DocException;
 import org.fugerit.java.doc.base.feature.DocFeatureRuntimeException;
 import org.fugerit.java.doc.base.feature.FeatureConfig;
 import org.fugerit.java.doc.base.model.DocBase;
+import org.fugerit.java.doc.base.parser.DocConvert;
 import org.fugerit.java.doc.base.parser.DocParser;
 import org.fugerit.java.doc.base.xml.DocXMLUtils;
 import org.slf4j.Logger;
@@ -70,6 +72,23 @@ public class DocFacadeSource {
 		PARSERS.setProperty( String.valueOf( SOURCE_TYPE_JSON_NG ) , TYPE_SOURCE_JSON_NG );
 		PARSERS.setProperty( String.valueOf( SOURCE_TYPE_KOTLIN ) , TYPE_SOURCE_KOTLIN );
 	}
+
+	private static String toConvertStringKey( int fromSourceType, int toSourceType ) {
+		return String.format( "%s_to_%s", fromSourceType, toSourceType );
+	}
+
+	private static final Properties CONVERTERS = new Properties();
+	static {
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_XML, DocFacadeSource.SOURCE_TYPE_JSON ) ) , "org.fugerit.java.doc.json.parse.DocXmlToJson" );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_XML, DocFacadeSource.SOURCE_TYPE_YAML ) ) , "org.fugerit.java.doc.yaml.parse.DocXmlToYaml" );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_JSON, DocFacadeSource.SOURCE_TYPE_XML ) ) , "org.fugerit.java.doc.json.parse.DocJsonToXml" );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_JSON, DocFacadeSource.SOURCE_TYPE_YAML ) ) , "org.fugerit.java.doc.yaml.parse.DocJsonToYaml" );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_YAML, DocFacadeSource.SOURCE_TYPE_XML ) ) , "org.fugerit.java.doc.yaml.parse.DocYamlToXml" );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_YAML, DocFacadeSource.SOURCE_TYPE_JSON ) ) , "org.fugerit.java.doc.yaml.parse.DocYamlToJson" );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_XML, DocFacadeSource.SOURCE_TYPE_XML ) ) , "org.fugerit.java.doc.base.facade.ReflectiveDocConvert" );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_JSON, DocFacadeSource.SOURCE_TYPE_JSON ) ) , "org.fugerit.java.doc.base.facade.ReflectiveDocConvert" );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_YAML, DocFacadeSource.SOURCE_TYPE_YAML ) ) , "org.fugerit.java.doc.base.facade.ReflectiveDocConvert" );
+	}
 	
 	public DocParser getParserForSource( int sourceType ) {
 		DocParser parser = null;
@@ -122,6 +141,26 @@ public class DocFacadeSource {
 			docBase = parser.parse(reader);
 		}
 		return docBase;
+	}
+
+	public static DocConvert findDocConvert( int fromSourceType, int toSourceType ) {
+		String docConvertType = CONVERTERS.getProperty( toConvertStringKey( fromSourceType, toSourceType ) );
+		if ( docConvertType == null ) {
+			throw new ConfigRuntimeException( String.format( "Converter from %s to %s not found.", fromSourceType, toSourceType ) );
+		} else {
+			logger.debug( "doc convert found : {}", docConvertType );
+			return SafeFunction.get( () -> (DocConvert)ClassHelper.newInstance( docConvertType ) );
+		}
+	}
+
+	public void convert(Reader from, int fromSourceType, Writer to, int toSourceType ) {
+		if ( isSourceSupported( fromSourceType ) && isSourceSupported( toSourceType ) ) {
+			SafeFunction.apply( () -> findDocConvert( fromSourceType, toSourceType ).convert( from, to ) );
+		} else if ( isSourceSupported( fromSourceType ) ) {
+			throw new ConfigRuntimeException( String.format( "Unsupported from source type: %s", toSourceType ) );
+		} else {
+			throw new ConfigRuntimeException( String.format( "Unsupported to source type: %s", fromSourceType ) );
+		}
 	}
 
 	public static Reader cleanSource( Reader source, int sourceType ) {

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/facade/DocFacadeSource.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/facade/DocFacadeSource.java
@@ -85,9 +85,9 @@ public class DocFacadeSource {
 		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_JSON, DocFacadeSource.SOURCE_TYPE_YAML ) ) , "org.fugerit.java.doc.yaml.parse.DocJsonToYaml" );
 		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_YAML, DocFacadeSource.SOURCE_TYPE_XML ) ) , "org.fugerit.java.doc.yaml.parse.DocYamlToXml" );
 		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_YAML, DocFacadeSource.SOURCE_TYPE_JSON ) ) , "org.fugerit.java.doc.yaml.parse.DocYamlToJson" );
-		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_XML, DocFacadeSource.SOURCE_TYPE_XML ) ) , "org.fugerit.java.doc.base.facade.ReflectiveDocConvert" );
-		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_JSON, DocFacadeSource.SOURCE_TYPE_JSON ) ) , "org.fugerit.java.doc.base.facade.ReflectiveDocConvert" );
-		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_YAML, DocFacadeSource.SOURCE_TYPE_YAML ) ) , "org.fugerit.java.doc.base.facade.ReflectiveDocConvert" );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_XML, DocFacadeSource.SOURCE_TYPE_XML ) ) , ReflectiveDocConvert.class.getName() );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_JSON, DocFacadeSource.SOURCE_TYPE_JSON ) ) , ReflectiveDocConvert.class.getName() );
+		CONVERTERS.setProperty( String.format( toConvertStringKey( DocFacadeSource.SOURCE_TYPE_YAML, DocFacadeSource.SOURCE_TYPE_YAML ) ) , ReflectiveDocConvert.class.getName() );
 	}
 	
 	public DocParser getParserForSource( int sourceType ) {

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/facade/ReflectiveDocConvert.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/facade/ReflectiveDocConvert.java
@@ -1,0 +1,17 @@
+package org.fugerit.java.doc.base.facade;
+
+import org.fugerit.java.core.cfg.ConfigException;
+import org.fugerit.java.core.io.StreamIO;
+import org.fugerit.java.doc.base.parser.DocConvert;
+
+import java.io.Reader;
+import java.io.Writer;
+
+public class ReflectiveDocConvert implements DocConvert {
+
+    @Override
+    public void convert(Reader from, Writer to) throws ConfigException {
+        ConfigException.apply( () -> StreamIO.pipeCharCloseBoth( from, to ) );
+    }
+
+}

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/parser/DocConvert.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/parser/DocConvert.java
@@ -1,0 +1,12 @@
+package org.fugerit.java.doc.base.parser;
+
+import org.fugerit.java.core.cfg.ConfigException;
+
+import java.io.Reader;
+import java.io.Writer;
+
+public interface DocConvert {
+
+    void convert(Reader from, Writer to) throws ConfigException;
+
+}

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/core/DocTypeHandlerCoreSource.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/core/DocTypeHandlerCoreSource.java
@@ -1,0 +1,38 @@
+package org.fugerit.java.doc.base.typehandler.core;
+
+import org.fugerit.java.core.io.StreamIO;
+import org.fugerit.java.doc.base.config.*;
+
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class DocTypeHandlerCoreSource extends DocTypeHandlerDefault {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = -50249858785381015L;
+
+    public static final DocTypeHandler HANDLER = new DocTypeHandlerCoreSource();
+
+    public static final DocTypeHandler HANDLER_UTF8 = new DocTypeHandlerCoreSource( StandardCharsets.UTF_8 );
+
+    public static final String TYPE = DocConfig.TYPE_TXT;
+
+    public static final String MODULE = "doc-core";
+
+    public DocTypeHandlerCoreSource(Charset charset ) {
+        super( TYPE, MODULE, null, charset );
+    }
+
+    public DocTypeHandlerCoreSource() {
+        super( TYPE, MODULE );
+    }
+
+    @Override
+    public void handle(DocInput docInput, DocOutput docOutput) throws Exception {
+        StreamIO.pipeCharCloseBoth( docInput.getReader() , new OutputStreamWriter( docOutput.getOs(), this.getCharset() ) );
+    }
+
+}

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/core/DocTypeHandlerCoreXML.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/core/DocTypeHandlerCoreXML.java
@@ -1,0 +1,44 @@
+package org.fugerit.java.doc.base.typehandler.core;
+
+import org.fugerit.java.core.cfg.ConfigException;
+import org.fugerit.java.core.io.StreamIO;
+import org.fugerit.java.doc.base.config.*;
+import org.fugerit.java.doc.base.facade.DocFacadeSource;
+import org.fugerit.java.doc.base.parser.DocParser;
+
+import java.io.OutputStreamWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class DocTypeHandlerCoreXML extends DocTypeHandlerDefault {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = -50249858785381015L;
+
+    public static final DocTypeHandler HANDLER = new DocTypeHandlerCoreXML();
+
+    public static final DocTypeHandler HANDLER_UTF8 = new DocTypeHandlerCoreXML( StandardCharsets.UTF_8 );
+
+    public static final String TYPE = DocConfig.TYPE_XML;
+
+    public static final String MODULE = "doc-core";
+
+    public DocTypeHandlerCoreXML(Charset charset ) {
+        super( TYPE, MODULE, null, charset );
+    }
+
+    public DocTypeHandlerCoreXML() {
+        super( TYPE, MODULE );
+    }
+
+    @Override
+    public void handle(DocInput docInput, DocOutput docOutput) throws Exception {
+        DocFacadeSource.getInstance().convert( docInput.getReader(),
+                docInput.getSource(), new OutputStreamWriter( docOutput.getOs() ), DocFacadeSource.SOURCE_TYPE_XML );
+    }
+
+}

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/core/DocTypeHandlerCoreXML.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/core/DocTypeHandlerCoreXML.java
@@ -1,14 +1,9 @@
 package org.fugerit.java.doc.base.typehandler.core;
 
-import org.fugerit.java.core.cfg.ConfigException;
-import org.fugerit.java.core.io.StreamIO;
 import org.fugerit.java.doc.base.config.*;
 import org.fugerit.java.doc.base.facade.DocFacadeSource;
-import org.fugerit.java.doc.base.parser.DocParser;
 
 import java.io.OutputStreamWriter;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/core/DocTypeHandlerCoreXMLUTF8.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/core/DocTypeHandlerCoreXMLUTF8.java
@@ -1,0 +1,17 @@
+package org.fugerit.java.doc.base.typehandler.core;
+
+import org.fugerit.java.doc.base.config.DocTypeHandler;
+import org.fugerit.java.doc.base.config.DocTypeHandlerDecorator;
+import org.fugerit.java.doc.base.config.DocTypeHandlerXMLUTF8;
+
+public class DocTypeHandlerCoreXMLUTF8 extends DocTypeHandlerDecorator {
+
+    private static final long serialVersionUID = -8512962951L;
+
+    public static final DocTypeHandler HANDLER = new DocTypeHandlerXMLUTF8();
+
+    public DocTypeHandlerCoreXMLUTF8() {
+        super( DocTypeHandlerCoreXML.HANDLER_UTF8 );
+    }
+
+}

--- a/fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/core/DocTypeHandlerCoreXMLUTF8.java
+++ b/fj-doc-base/src/main/java/org/fugerit/java/doc/base/typehandler/core/DocTypeHandlerCoreXMLUTF8.java
@@ -2,13 +2,12 @@ package org.fugerit.java.doc.base.typehandler.core;
 
 import org.fugerit.java.doc.base.config.DocTypeHandler;
 import org.fugerit.java.doc.base.config.DocTypeHandlerDecorator;
-import org.fugerit.java.doc.base.config.DocTypeHandlerXMLUTF8;
 
 public class DocTypeHandlerCoreXMLUTF8 extends DocTypeHandlerDecorator {
 
     private static final long serialVersionUID = -8512962951L;
 
-    public static final DocTypeHandler HANDLER = new DocTypeHandlerXMLUTF8();
+    public static final DocTypeHandler HANDLER = new DocTypeHandlerCoreXMLUTF8();
 
     public DocTypeHandlerCoreXMLUTF8() {
         super( DocTypeHandlerCoreXML.HANDLER_UTF8 );

--- a/fj-doc-base/src/main/resources/META-INF/native-image/org.fugerit.java/fj-doc-base/reflect-config.json
+++ b/fj-doc-base/src/main/resources/META-INF/native-image/org.fugerit.java/fj-doc-base/reflect-config.json
@@ -3137,6 +3137,15 @@
   "condition" : {
     "typeReachable" : "org.fugerit.java.doc.base.facade.DocFacadeSource"
   },
+  "name" : "org.fugerit.java.doc.base.parser.DocConvert",
+  "methods" : [ {
+    "name" : "convert",
+    "parameterTypes" : [ "java.io.Reader", "java.io.Writer" ]
+  } ]
+}, {
+  "condition" : {
+    "typeReachable" : "org.fugerit.java.doc.base.facade.DocFacadeSource"
+  },
   "name" : "org.fugerit.java.doc.base.parser.DocEvalWithDataModel",
   "methods" : [ {
     "name" : "evalWithDataModel",

--- a/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/facade/TestDocFacadeSource.java
+++ b/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/facade/TestDocFacadeSource.java
@@ -91,12 +91,14 @@ class TestDocFacadeSource {
 		assertEquals( input, DocFacadeSource.cleanSource( input, DocFacadeSource.SOURCE_TYPE_YAML ) );
 	}
 
+	private static final DocFacadeSource DOC_FACADE_SOURCE = DocFacadeSource.getInstance();
+
 	@Test
 	void testFromSourceNotSupported() throws IOException {
 		try ( StringReader from = new StringReader( "{}" );
 			StringWriter to = new StringWriter() ) {
 			assertThrows( ConfigRuntimeException.class,
-					() -> DocFacadeSource.getInstance().convert( from, DocFacadeSource.SOURCE_TYPE_JSON, to, DocFacadeSource.SOURCE_TYPE_XML ) );
+					() -> DOC_FACADE_SOURCE.convert( from, DocFacadeSource.SOURCE_TYPE_JSON, to, DocFacadeSource.SOURCE_TYPE_XML ) );
 		}
 	}
 
@@ -105,7 +107,7 @@ class TestDocFacadeSource {
 		try ( StringReader from = new StringReader( "<doc/>" );
 			  StringWriter to = new StringWriter() ) {
 			assertThrows( ConfigRuntimeException.class,
-					() -> DocFacadeSource.getInstance().convert( from, DocFacadeSource.SOURCE_TYPE_XML, to, DocFacadeSource.SOURCE_TYPE_YAML ) );
+					() -> DOC_FACADE_SOURCE.convert( from, DocFacadeSource.SOURCE_TYPE_XML, to, DocFacadeSource.SOURCE_TYPE_YAML ) );
 		}
 	}
 

--- a/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/facade/TestDocFacadeSource.java
+++ b/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/facade/TestDocFacadeSource.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.io.StringWriter;
 
 import org.fugerit.java.core.cfg.ConfigRuntimeException;
 import org.fugerit.java.core.function.SafeFunction;
@@ -88,6 +89,40 @@ class TestDocFacadeSource {
 		assertEquals( input, DocFacadeSource.cleanSource( input, DocFacadeSource.SOURCE_TYPE_XML ) );
 		assertEquals( input, DocFacadeSource.cleanSource( input, DocFacadeSource.SOURCE_TYPE_JSON ) );
 		assertEquals( input, DocFacadeSource.cleanSource( input, DocFacadeSource.SOURCE_TYPE_YAML ) );
+	}
+
+	@Test
+	void testFromSourceNotSupported() throws IOException {
+		try ( StringReader from = new StringReader( "{}" );
+			StringWriter to = new StringWriter() ) {
+			Assertions.assertThrows( ConfigRuntimeException.class,
+					() -> DocFacadeSource.getInstance().convert( from, DocFacadeSource.SOURCE_TYPE_JSON, to, DocFacadeSource.SOURCE_TYPE_XML ) );
+		}
+	}
+
+	@Test
+	void testToSourceNotSupported() throws IOException {
+		try ( StringReader from = new StringReader( "<doc/>" );
+			  StringWriter to = new StringWriter() ) {
+			Assertions.assertThrows( ConfigRuntimeException.class,
+					() -> DocFacadeSource.getInstance().convert( from, DocFacadeSource.SOURCE_TYPE_XML, to, DocFacadeSource.SOURCE_TYPE_YAML ) );
+		}
+	}
+
+	@Test
+	void testDocConvertNotFound() {
+		Assertions.assertThrows( ConfigRuntimeException.class,
+				() -> DocFacadeSource.findDocConvert( DocFacadeSource.SOURCE_TYPE_XML, Integer.MAX_VALUE ) );
+	}
+
+	@Test
+	void testReflectiveConversionXml() throws IOException {
+		String input = "<doc></doc>";
+		try ( StringReader from = new StringReader( input );
+			  StringWriter to = new StringWriter() ) {
+			DocFacadeSource.getInstance().convert( from, DocFacadeSource.SOURCE_TYPE_XML, to, DocFacadeSource.SOURCE_TYPE_XML );
+			Assertions.assertEquals( input, to.toString() );
+		}
 	}
 
 }

--- a/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/facade/TestDocFacadeSource.java
+++ b/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/facade/TestDocFacadeSource.java
@@ -95,7 +95,7 @@ class TestDocFacadeSource {
 	void testFromSourceNotSupported() throws IOException {
 		try ( StringReader from = new StringReader( "{}" );
 			StringWriter to = new StringWriter() ) {
-			Assertions.assertThrows( ConfigRuntimeException.class,
+			assertThrows( ConfigRuntimeException.class,
 					() -> DocFacadeSource.getInstance().convert( from, DocFacadeSource.SOURCE_TYPE_JSON, to, DocFacadeSource.SOURCE_TYPE_XML ) );
 		}
 	}
@@ -104,14 +104,14 @@ class TestDocFacadeSource {
 	void testToSourceNotSupported() throws IOException {
 		try ( StringReader from = new StringReader( "<doc/>" );
 			  StringWriter to = new StringWriter() ) {
-			Assertions.assertThrows( ConfigRuntimeException.class,
+			assertThrows( ConfigRuntimeException.class,
 					() -> DocFacadeSource.getInstance().convert( from, DocFacadeSource.SOURCE_TYPE_XML, to, DocFacadeSource.SOURCE_TYPE_YAML ) );
 		}
 	}
 
 	@Test
 	void testDocConvertNotFound() {
-		Assertions.assertThrows( ConfigRuntimeException.class,
+		assertThrows( ConfigRuntimeException.class,
 				() -> DocFacadeSource.findDocConvert( DocFacadeSource.SOURCE_TYPE_XML, Integer.MAX_VALUE ) );
 	}
 

--- a/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/typehandler/core/TestCoreHandlers.java
+++ b/fj-doc-base/src/test/java/test/org/fugerit/java/doc/base/typehandler/core/TestCoreHandlers.java
@@ -1,0 +1,37 @@
+package test.org.fugerit.java.doc.base.typehandler.core;
+
+import org.fugerit.java.doc.base.config.DocInput;
+import org.fugerit.java.doc.base.config.DocOutput;
+import org.fugerit.java.doc.base.config.DocTypeHandler;
+import org.fugerit.java.doc.base.typehandler.core.DocTypeHandlerCoreSource;
+import org.fugerit.java.doc.base.typehandler.core.DocTypeHandlerCoreXMLUTF8;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+
+class TestCoreHandlers {
+
+    private static final String INPUT_DOC = "<doc/>";
+
+    private String testWorker( DocTypeHandler handler ) throws Exception {
+        try (StringReader from = new StringReader(INPUT_DOC);
+             ByteArrayOutputStream os = new ByteArrayOutputStream();
+        ) {
+            handler.handle(DocInput.newInput( handler.getType(), from ), DocOutput.newOutput(os));
+            return os.toString();
+        }
+    }
+
+    @Test
+    void testCoreXml()  throws Exception {
+        Assertions.assertEquals( INPUT_DOC, this.testWorker( DocTypeHandlerCoreXMLUTF8.HANDLER ) );
+    }
+
+    @Test
+    void testCoreSource()  throws Exception {
+        Assertions.assertEquals( INPUT_DOC, this.testWorker(  DocTypeHandlerCoreSource.HANDLER ) );
+    }
+
+}

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/00_2_release_notes.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/00_2_release_notes.adoc
@@ -6,6 +6,9 @@ Whereas the link:https://github.com/fugerit-org/fj-doc/blob/main/CHANGELOG.md[CH
 [#doc-release-notes-unreleased]
 ==== Unreleased
 
+- fixed org.fugerit.java.doc.base.config.DocTypeHandlerXML renders the source document in the source format (i.e. JSON or YAML) link:https://github.com/fugerit-org/fj-doc/issues/519[#519]
+- added core type handlers for XML, JSON and YAML formats link:https://github.com/fugerit-org/fj-doc/issues/519[#519]
+
 [#doc-release-notes-8-16-5]
 ==== Version 8.16.5 [2025-09-29]
 

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/06_doc_handlers.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/06_doc_handlers.adoc
@@ -119,3 +119,60 @@ Each section describing a specific doc handler will contain this quick reference
 - *compliance level* : _COMPLETE_, _HIGH_, _MEDIUM_, _LOW_, The level of support to xref:#doc-format-entry-point[Venus Doc Format].
 - *compliance detail* : The limitations to the support of the xref:#doc-format-entry-point[Venus Doc Format] (for instance : unsupported elements or attributes).
 - *native ready* : _YES_, _NO_ (If the doc handler is ready for native compilation with link:https://www.graalvm.org/[GraalVM]).
+
+=== Core Type Handlers
+
+Additionally some type handlers for source formats (i.e. XML, JSON) are available.
+
+They differ from other type handlers as they only handle the xref:#doc-format-entry-point[Doc Source Format] and converting it from one source type (i.e. XML) to another source type (i.e. JSON).
+
+[cols="4,2,1,3,3", options="header"]
+|========================================================================================================================================
+
+| doc-handler
+| module
+| type
+| description
+| notes
+
+| org.fugerit.java.doc.base.typehandler.core.&#8203;DocTypeHandlerCoreXML
+| fj-doc-base
+| XML
+| Renders a XML document in the XML Doc Source Format
+| native ready (1)
+
+| org.fugerit.java.doc.base.typehandler.core.&#8203;DocTypeHandlerCoreXMLUTF8
+| fj-doc-base
+| XML
+| Renders a XML document in the XML Doc Source Format
+| native ready (1)
+
+| org.fugerit.java.doc.json.typehandler.&#8203;DocTypeHandlerCoreJSON
+| fj-doc-base-json
+| JSON
+| Renders a JSON document in the JSON Doc Source Format
+| native ready (1)
+
+| org.fugerit.java.doc.json.typehandler.&#8203;DocTypeHandlerCoreJSONUTF8
+| fj-doc-base-json
+| JSON
+| Renders a JSON document in the JSON Doc Source Format
+| native ready (1)
+
+| org.fugerit.java.doc.json.typehandler.&#8203;DocTypeHandlerCoreYAML
+| fj-doc-base-json
+| YAML
+| Renders a YAML document in the YAML Doc Source Format
+| native ready (1)
+
+| org.fugerit.java.doc.json.typehandler.&#8203;DocTypeHandlerCoreYAMLUTF8
+| fj-doc-base-json
+| YAML
+| Renders a YAML document in the YAML Doc Source Format
+| native ready (1)
+
+| org.fugerit.java.doc.base.typehandler.core.&#8203;DocTypeHandlerCoreSource
+| fj-doc-base
+| txt
+| Just output the current source with no modification.
+| native ready (1)

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/10_1_invalid-xml-character.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/10_1_invalid-xml-character.adoc
@@ -1,7 +1,7 @@
 
 <<<
 [#doc-troubleshooting-invalid-xml-character]
-=== An invalid XML character
+=== An invalid XML character (Unicode: ???) was found in the element content of the document
 
 Sometimes it can happen to get errors like :
 

--- a/fj-doc-maven-plugin/src/main/java/org/fugerit/java/doc/project/facade/VenusContext.java
+++ b/fj-doc-maven-plugin/src/main/java/org/fugerit/java/doc/project/facade/VenusContext.java
@@ -41,6 +41,8 @@ public class VenusContext {
 
     public static final String VERSION_NA_FREEMARKER_NATIVE = "8.11.8";
 
+    public static final String VERSION_NA_CORE_HANDLERS = "8.16.5";
+
     private static final String VENUS_DIRECT_CONFIG_DEFAULT = "venus-direct-config";
 
     @Getter
@@ -161,6 +163,11 @@ public class VenusContext {
         return "DocHelper";
     }
 
+    public boolean isCoreHandlersNotAvailable() {
+        return !VersionCheck.isMajorThan( this.getVersion(), VERSION_NA_CORE_HANDLERS );
+    }
+
+
     public boolean isVerifyPluginNotAvailable() {
         return VersionCheck.isMajorThan( VERSION_NA_VERIFY_PLUGIN, this.getVersion() );
     }
@@ -180,7 +187,7 @@ public class VenusContext {
     private File getAndCreateFolder( File file ) {
         if ( !file.exists() ) {
             boolean result = file.mkdirs();
-            log.info( "folder doesn't exists: {}, mkdirs: ", file.getAbsolutePath(), result );
+            log.info( "folder doesn't exists: {}, mkdirs: {}", file.getAbsolutePath(), result );
         }
         return file;
     }

--- a/fj-doc-maven-plugin/src/main/resources/config/template/fm-doc-process-config-template.ftl
+++ b/fj-doc-maven-plugin/src/main/resources/config/template/fm-doc-process-config-template.ftl
@@ -15,10 +15,24 @@
     -->
 
     <docHandlerConfig registerById="true">
+
         <!-- Type handler for markdown format -->
         <docHandler id="md-ext" info="md" type="org.fugerit.java.doc.base.typehandler.markdown.SimpleMarkdownExtTypeHandler" />
-        <!-- Type henalder for xml format, generates the source xml:doc -->
+        <#if context.coreHandlersNotAvailable>
+        <!-- Type handler for xml format, generates the source xml:doc -->
         <docHandler id="xml-doc" info="xml" type="org.fugerit.java.doc.base.config.DocTypeHandlerXMLUTF8" />
+        <#else>
+        <!-- Type handler for xml format, generates the source xml:doc -->
+        <docHandler id="xml-doc" info="xml" type="org.fugerit.java.doc.base.typehandler.core.DocTypeHandlerCoreXMLUTF8" />
+        <#if context.modules?seq_contains("fj-doc-base-json")>
+        <!-- Type handler for JSON format, generates the source json:doc -->
+        <docHandler id="json-doc" info="json" type="org.fugerit.java.doc.json.typehandler.DocTypeHandlerCoreJSONUTF8" />
+        </#if>
+        <#if context.modules?seq_contains("fj-doc-base-yaml")>
+        <!-- Type handler for YAML format, generates the source json:doc -->
+        <docHandler id="yaml-doc" info="yaml" type="org.fugerit.java.doc.yaml.typehandler.DocTypeHandlerCoreYAMLUTF8" />
+        </#if>
+        </#if>
         <!-- Type handler for html using freemarker -->
         <docHandler id="html-fm" info="html" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlTypeHandlerEscapeUTF8" />
         <!-- Type handler for html using freemarker (fragment version, only generates body content no html or head part -->

--- a/fj-doc-maven-plugin/src/test/java/test/org/fugerit/java/doc/project/facade/TestAddVenusFacade.java
+++ b/fj-doc-maven-plugin/src/test/java/test/org/fugerit/java/doc/project/facade/TestAddVenusFacade.java
@@ -205,6 +205,30 @@ class TestAddVenusFacade {
     }
 
     @Test
+    void testMojoCoreHandlers() throws IOException, MojoExecutionException, MojoFailureException {
+        for ( String currentConfig : Arrays.asList( "ok3-pom" ) ) {
+            File projectDir = this.initConfigWorker( currentConfig );
+            MojoAdd mojoAdd = new MojoAdd() {
+                @Override
+                public void execute() throws MojoExecutionException, MojoFailureException {
+                    this.version = "8.16.6";
+                    this.extensions = "fj-doc-base,fj-doc-base-json,fj-doc-base-yaml,fj-doc-freemarker,fj-doc-mod-fop,fj-doc-mod-poi,fj-doc-mod-opencsv";
+                    this.projectFolder = projectDir.getAbsolutePath();
+                    this.addDocFacade = true;
+                    this.force = true;
+                    this.excludeXmlApis = true;
+                    this.addVerifyPlugin = true;
+                    this.addJunit5 = true;
+                    this.addLombok = true;
+                    super.execute();
+                }
+            };
+            mojoAdd.execute();
+            Assertions.assertTrue( projectDir.exists() );
+        }
+    }
+
+    @Test
     void testFjVersionCheck() {
         Model model = new Model();
         String projectPomFjCoreVersion = BasicVenusFacade.versionToCheck( FJCoreMaven.FJ_CORE_GROUP_ID, FJCoreMaven.FJ_CORE_ARTIFACT_ID, model );

--- a/fj-doc-maven-plugin/src/test/java/test/org/fugerit/java/doc/project/facade/TestVenusContext.java
+++ b/fj-doc-maven-plugin/src/test/java/test/org/fugerit/java/doc/project/facade/TestVenusContext.java
@@ -18,12 +18,19 @@ class TestVenusContext {
         Assertions.assertNotNull( context.getTestResourcesFolder() );
         Assertions.assertNotNull( context.getMainResourcesFolder() );
         Assertions.assertFalse( context.isAsciidocFreemarkerHandlerAvailable() );
+        Assertions.assertTrue( context.isCoreHandlersNotAvailable() );
     }
 
     @Test
     void testAsciiDocCheck() {
         VenusContext context = new VenusContext( TARGET, "8.10.8", "fj-doc-base" );
         Assertions.assertTrue( context.isAsciidocFreemarkerHandlerAvailable() );
+    }
+
+    @Test
+    void testVenusContextCoreHandlers() {
+        VenusContext context = new VenusContext( TARGET, "8.17.0", "fj-doc-base" );
+        Assertions.assertFalse( context.isCoreHandlersNotAvailable() );
     }
 
 }

--- a/fj-doc-playground-quarkus/src/main/docs/asciidoc/features/doc-config-convert.adoc
+++ b/fj-doc-playground-quarkus/src/main/docs/asciidoc/features/doc-config-convert.adoc
@@ -68,7 +68,7 @@ xsi:schemaLocation="https://freemarkerdocprocess.fugerit.org https://www.fugerit
 		<!-- Type handler for markdown format -->
 		<docHandler id="md-ext" info="md" type="org.fugerit.java.doc.base.typehandler.markdown.SimpleMarkdownExtTypeHandler" />
 		<!-- Type henalder for xml format, generates the source xml:doc -->
-		<docHandler id="xml-doc" info="xml" type="org.fugerit.java.doc.base.config.DocTypeHandlerXMLUTF8" />
+		<docHandler id="xml-doc" info="xml" type="org.fugerit.java.doc.base.typehandler.core.DocTypeHandlerCoreXMLUTF8UTF8" />
 
 		<!-- Type handlers for html using freemarker -->
 		<docHandler id="html-fm" info="html" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlTypeHandlerEscapeUTF8" />

--- a/fj-doc-playground-quarkus/src/main/docs/asciidoc/features/doc-config-convert.adoc
+++ b/fj-doc-playground-quarkus/src/main/docs/asciidoc/features/doc-config-convert.adoc
@@ -68,7 +68,7 @@ xsi:schemaLocation="https://freemarkerdocprocess.fugerit.org https://www.fugerit
 		<!-- Type handler for markdown format -->
 		<docHandler id="md-ext" info="md" type="org.fugerit.java.doc.base.typehandler.markdown.SimpleMarkdownExtTypeHandler" />
 		<!-- Type henalder for xml format, generates the source xml:doc -->
-		<docHandler id="xml-doc" info="xml" type="org.fugerit.java.doc.base.typehandler.core.DocTypeHandlerCoreXMLUTF8UTF8" />
+		<docHandler id="xml-doc" info="xml" type="org.fugerit.java.doc.base.typehandler.core.DocTypeHandlerCoreXMLUTF8" />
 
 		<!-- Type handlers for html using freemarker -->
 		<docHandler id="html-fm" info="html" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlTypeHandlerEscapeUTF8" />

--- a/fj-doc-playground-quarkus/src/main/java/org/fugerit/java/doc/playground/doc/GenerateRest.java
+++ b/fj-doc-playground-quarkus/src/main/java/org/fugerit/java/doc/playground/doc/GenerateRest.java
@@ -49,9 +49,9 @@ public class GenerateRest {
                 output.setDocOutputBase64(Base64.getEncoder().encodeToString(data));
                 output.setGenerationTime(CheckpointUtils.formatTimeDiffMillis(time, System.currentTimeMillis()));
             } catch (DocFeatureRuntimeException e) {
-                this.setOutputMessage( output, e, e.getMessages() );
+                this.setOutputMessage(output, e, e.getMessages());
             } catch (Exception e) {
-                this.setOutputMessage( output, e, null );
+                this.setOutputMessage(output, e, null);
             }
             return Response.ok().entity(output).build();
         });

--- a/fj-doc-playground-quarkus/src/main/react/src/playground/DocXmlEditor.jsx
+++ b/fj-doc-playground-quarkus/src/main/react/src/playground/DocXmlEditor.jsx
@@ -193,6 +193,32 @@ const DocXmlEditor = ({handleOpenDialog, setHelpContent}) => {
 					value={decodedStringAtoB}
 					width='100%'
 				/>
+            } else if ( docFormat === 'JSON' ) {
+                let decodedStringAtoB = myAtob(docOutput);
+                outputData = <AceEditor
+                    mode='json'
+                    theme="xcode"
+                    name="DOC_JSON_OUTPUT"
+                    editorProps={{ $blockScrolling: true }}
+                    enableBasicAutocompletion={true}
+                    enableLiveAutocompletion={true}
+                    enableSnippets={true}
+                    value={decodedStringAtoB}
+                    width='100%'
+                />
+            } else if ( docFormat === 'YAML' ) {
+                let decodedStringAtoB = myAtob(docOutput);
+                outputData = <AceEditor
+                    mode='yaml'
+                    theme="xcode"
+                    name="DOC_YAML_OUTPUT"
+                    editorProps={{ $blockScrolling: true }}
+                    enableBasicAutocompletion={true}
+                    enableLiveAutocompletion={true}
+                    enableSnippets={true}
+                    value={decodedStringAtoB}
+                    width='100%'
+                />
 			} else if ( docFormat === 'CSV' ) {
 				let decodedStringAtoB = myAtob(docOutput);
 				outputData = <AceEditor
@@ -278,6 +304,8 @@ const DocXmlEditor = ({handleOpenDialog, setHelpContent}) => {
 							<MenuItem value='XLSX'>XLSX</MenuItem>
 							<MenuItem value='MD'>Markdown (MD)</MenuItem>
 							<MenuItem value='XML'>Venus XML Doc</MenuItem>
+                            <MenuItem value='JSON'>Venus JSON Doc</MenuItem>
+                            <MenuItem value='YAML'>Venus YAML Doc</MenuItem>
 							<MenuItem value='FO'>XSL-FO</MenuItem>
 							<MenuItem value='CSV'>CSV</MenuItem>
 							<MenuItem value='OPENPDF'>PDF (openpdf)</MenuItem>

--- a/fj-doc-playground-quarkus/src/main/resources/playground-config/fm-playground-doc-process.xml
+++ b/fj-doc-playground-quarkus/src/main/resources/playground-config/fm-playground-doc-process.xml
@@ -62,7 +62,9 @@
 		  </docHandlerCustomConfig>
 		</docHandler>
 		<docHandler id="md" info="md" type="org.fugerit.java.doc.base.typehandler.markdown.SimpleMarkdownExtTypeHandlerNoCommentsUTF8" />
-		<docHandler id="xml" info="xml" type="org.fugerit.java.doc.base.typehandler.core.DocTypeHandlerCoreXMLUTF8UTF8" />
+		<docHandler id="xml" info="xml" type="org.fugerit.java.doc.base.typehandler.core.DocTypeHandlerCoreXMLUTF8" />
+        <docHandler id="json" info="json" type="org.fugerit.java.doc.json.typehandler.DocTypeHandlerCoreJSONUTF8" />
+        <docHandler id="yaml" info="yaml" type="org.fugerit.java.doc.yaml.typehandler.DocTypeHandlerCoreYAMLUTF8" />
 		<docHandler id="xls" info="xls" type="org.fugerit.java.doc.mod.poi.XlsPoiTypeHandler" />
 		<docHandler id="xlsx" info="xlsx" type="org.fugerit.java.doc.mod.poi.XlsxPoiTypeHandler" />			
 		<docHandler id="fo" info="fo" type="org.fugerit.java.doc.mod.fop.FreeMarkerFopTypeHandlerUTF8" />

--- a/fj-doc-playground-quarkus/src/main/resources/playground-config/fm-playground-doc-process.xml
+++ b/fj-doc-playground-quarkus/src/main/resources/playground-config/fm-playground-doc-process.xml
@@ -62,7 +62,7 @@
 		  </docHandlerCustomConfig>
 		</docHandler>
 		<docHandler id="md" info="md" type="org.fugerit.java.doc.base.typehandler.markdown.SimpleMarkdownExtTypeHandlerNoCommentsUTF8" />
-		<docHandler id="xml" info="xml" type="org.fugerit.java.doc.base.config.DocTypeHandlerXMLUTF8" />
+		<docHandler id="xml" info="xml" type="org.fugerit.java.doc.base.typehandler.core.DocTypeHandlerCoreXMLUTF8UTF8" />
 		<docHandler id="xls" info="xls" type="org.fugerit.java.doc.mod.poi.XlsPoiTypeHandler" />
 		<docHandler id="xlsx" info="xlsx" type="org.fugerit.java.doc.mod.poi.XlsxPoiTypeHandler" />			
 		<docHandler id="fo" info="fo" type="org.fugerit.java.doc.mod.fop.FreeMarkerFopTypeHandlerUTF8" />


### PR DESCRIPTION
Actually new type handlers have been added for XML, JSON and YAML format.

They have been named "core type handlers" and only handle the native Venus Doc Format.