### PR TITLE
Potential fix for code scanning alert no. 114: Uncontrolled data used in path expression

### DIFF
--- a/fj-doc-maven-plugin/src/main/java/org/fugerit/java/doc/project/facade/FeatureFacade.java
+++ b/fj-doc-maven-plugin/src/main/java/org/fugerit/java/doc/project/facade/FeatureFacade.java
@@ -24,11 +24,11 @@ public class FeatureFacade {
      * Checks that the given file is inside the baseFolder after normalization.
      * Throws IOException if not.
      */
-    private static void checkIfInBaseFolder(File baseFolder, File file) throws IOException {
+    public static void checkIfInBaseFolder(File baseFolder, File file) throws IOException {
         Path base = baseFolder.getCanonicalFile().toPath().normalize();
         Path target = file.getCanonicalFile().toPath().normalize();
         if (!target.startsWith(base)) {
-            throw new IOException("File path " + file.getCanonicalPath() + " is not within permitted base folder " + baseFolder.getCanonicalPath());
+            throw new IOException( String.format( "File path %s is not within permitted base folder %s", file.getCanonicalPath(), baseFolder.getCanonicalPath() ) );
         }
     }
 
@@ -50,7 +50,7 @@ public class FeatureFacade {
         }
     }
 
-    protected static void insureParent( File file ) throws IOException {
+    public static void insureParent( File file ) throws IOException {
         File parentFile = file.getParentFile();
         // Defensive: check parent is within project's root as well
         if (parentFile != null) {
@@ -58,9 +58,9 @@ public class FeatureFacade {
             if (baseFolder != null) {
                 checkIfInBaseFolder(baseFolder, parentFile);
             }
-        }
-        if ( !parentFile.exists() ) {
-            log.info( "creates parent directory {}, mkdirs:? {}", parentFile.getCanonicalPath(), parentFile.mkdirs() );
+            if ( !parentFile.exists() ) {
+                log.info( "creates parent directory {}, mkdirs:? {}", parentFile.getCanonicalPath(), parentFile.mkdirs() );
+            }
         }
     }
 

--- a/fj-doc-maven-plugin/src/test/java/test/org/fugerit/java/doc/project/facade/TestFeatureFacade.java
+++ b/fj-doc-maven-plugin/src/test/java/test/org/fugerit/java/doc/project/facade/TestFeatureFacade.java
@@ -1,0 +1,46 @@
+package test.org.fugerit.java.doc.project.facade;
+
+import org.fugerit.java.doc.project.facade.FeatureFacade;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+class TestFeatureFacade {
+
+    @Test
+    void checkIfInBaseFolderTestOk() throws IOException {
+        File baseFolder = new File( "." );
+        File file = new File( "pom.xml" );
+        FeatureFacade.checkIfInBaseFolder( baseFolder, file );
+        Assertions.assertTrue( file.exists() );
+    }
+
+    @Test
+    void checkIfInBaseFolderTestKo() {
+        File baseFolder = new File( "fj-doc-base" );
+        File file = new File( "pom.xml" );
+        Assertions.assertThrows( IOException.class, () -> FeatureFacade.checkIfInBaseFolder( baseFolder, file ) );
+    }
+
+    @Test
+    void insureParentTestNull1() throws IOException {
+        File root = File.listRoots()[0];
+        FeatureFacade.insureParent( root );
+        Assertions.assertTrue( root.exists() );
+    }
+
+    @Test
+    void insureParentTestNull2() throws IOException {
+        File root = File.listRoots()[0];
+        if ( root != null ) {
+            File[] list = root.listFiles();
+            if ( list != null && list.length > 0 ) {
+                FeatureFacade.insureParent( list[0] );
+                Assertions.assertTrue( root.exists() );
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Potential fix for [https://github.com/fugerit-org/fj-doc/security/code-scanning/114](https://github.com/fugerit-org/fj-doc/security/code-scanning/114)

To fix this, we need to ensure that **every time user input is used to construct a file or folder path**, it is validated to prevent traversals and keep the output within authorized boundaries. The most robust approach is to check that the resolved/normalized path is strictly within a designated base directory (e.g., the created project temp folder).

Specifically:
- In `FeatureFacade.copyFlavourList` and the downstream methods (`copyResourcesList`, `copyFile`, `insureParent`), ensure that the `baseFolder` and all resulting file operations are within an authorized area.
- In `FeatureFacade.copyFile`, before creating any directories or files, resolve the file (output location) and check that it still resides in (is a descendant of) `baseFolder` (or `projectFolder`), after normalization.
- If not, throw an exception and abort.

Implementation:
- Add a helper method (e.g., `checkIfInBaseFolder(File baseFolder, File file)`).
- Use Java's `Path#normalize` and `Path#toAbsolutePath`, and check that `file` is a descendant of `baseFolder`.
- Call this validation in `copyFile` and/or `insureParent` (or both, for clarity), before actual creation or writing.

Affected file and methods:  
- `fj-doc-maven-plugin/src/main/java/org/fugerit/java/doc/project/facade/FeatureFacade.java`: add helper method, call validation in `copyFile` and `insureParent`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
