### PR TITLE
docs: documentation review - fix typos and improve clarity

### DIFF
--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/00_4_useful_resources.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/00_4_useful_resources.adoc
@@ -1,5 +1,5 @@
 [#doc-useful-resources]
-=== Useful resources
+=== Useful Resources
 
 This section contains some useful resources.
 
@@ -7,7 +7,7 @@ This section contains some useful resources.
 
 The online playground where you can try Fugerit Venus Doc features :
 
-link:include::chapters/https://docs.fugerit.org/fj-doc-playground/home/[https://docs.fugerit.org/fj-doc-playground/home/]
+link:https://docs.fugerit.org/fj-doc-playground/home/[https://docs.fugerit.org/fj-doc-playground/home/]
 
 [#doc-res-link-sample-index]
 ==== Venus Fugerit Doc sample index

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/00_introduction.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/00_introduction.adoc
@@ -4,7 +4,7 @@
 ....
 mindmap
   root((Venus<br/>Doc))
-    Fugerti Doc Source Format
+    Fugerit Doc Source Format
       XML Source - default
       JSON Source
       YAML Source
@@ -55,4 +55,4 @@ flowchart TB
 
 **@2024** Matteo Franci - **CC BY 4.0** - ATTRIBUTION 4.0 INTERNATIONAL - https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en
 
-All trademarks, logos and brand names are the property of their respective owners. All company, product and service names used in this website are for identification purposes only. Use of these names,trademarks and brands does not imply endorsement.
+All trademarks, logos and brand names are the property of their respective owners. All company, product and service names used in this website are for identification purposes only. Use of these names, trademarks and brands does not imply endorsement.

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/01_quickstart.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/01_quickstart.adoc
@@ -1,7 +1,7 @@
 <<<
 == Quickstart
 
-This section cover the creation of a new maven project, configured for Venus Doc.
+This section covers the creation of a new Maven project configured for Venus Doc.
 
 === New maven project
 
@@ -17,7 +17,7 @@ mvn org.fugerit.java:fj-doc-maven-plugin:init \
 ----
 
 And you will get a project folder named after the artifactId.
-See the README.md in the project folder for further infos.
+See the README.md in the project folder for further information.
 
 In case of 'quarkus-3' flavour, for instance, simply :
 

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/02_1_maven_plugin_add.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/02_1_maven_plugin_add.adoc
@@ -1,7 +1,7 @@
 [#maven-plugin-goal-add]
 === Goal 'add'
 
-This goal add Fugerit Venus Doc configuration to an existing maven project.
+This goal adds Fugerit Venus Doc configuration to an existing Maven project.
 
 Simply run the plugin in the folder containing your project POM :
 
@@ -26,13 +26,13 @@ mvn org.fugerit.java:fj-doc-maven-plugin:add \
 | excludeXmlApis     | false    | false           | It will exclude dependency xml-apis:xml-apis
 | addExclusions      | false    |                 | Add comma separated exclusion, for instance : xml-apis:xml-apis,${groupId}:${artificatId}
 | addVerifyPlugin    | true     | true            | If set to true, it will configure the 'verify' goal on the project
-| addDirectPlugin    | false     | true            | If set to true, it will configure the 'direct' goal on the project
+| addDirectPlugin    | false    | true            | If set to true, it will configure the 'direct' goal on the project
 | addJunit5          | true     | true            | If set to true, it will add junit5 (test scope) and basic test
 | addLombok          | true     | true            | If set to true, it will add lombok (provided scope) and slf4j-simple (test scope)
 | addDependencyOnTop | true     | false           | If set to true, added dependencies will be added before existing ones
 | freemarkerVersion  | true     | 2.3.32          | Freemarker compatibility version (max 2.3.33)
-| simpleMpdel          | true     | false            | If set to true, modification to pom.xml will be light, dependencies for addLombok and addJunit will be ignored. addVerifyPlugin param will be ignored.
-| basePackage          | false     |             | If set given base package is used, otherwise base java package will be derived from groupId and artifactiId. (since fj-doc 8.13.13)
+| simpleModel          | true     | false            | If set to true, modification to pom.xml will be light, dependencies for addLombok and addJunit will be ignored. addVerifyPlugin param will be ignored.
+| basePackage          | false     |             | If set given base package is used, otherwise base java package will be derived from groupId and artifactId. (since fj-doc 8.13.13)
 |====================================================================================================================================================================================
 
 [#available-extensions]

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/02_2_maven_plugin_init.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/02_2_maven_plugin_init.adoc
@@ -41,14 +41,14 @@ NOTE: it is possible to set any property from 'add' goal, except 'projectFolder'
 |====================================================================================================================================
 | flavour      | model | description
 | vanilla       | maven | Vanilla java, with maven packaging
-| direct       | maven | Direct, similar to 'vanilla' but parameter 'addDirectPlugin' set to 'true and 'addDocFacade' set to 'false'
+| direct       | maven | Direct, similar to 'vanilla' but parameter 'addDirectPlugin' set to 'true' and 'addDocFacade' set to 'false'
 | quarkus-3        | maven | Based on link:https://quarkus.io/[Quarkus 3], with maven packaging (yaml)
 | quarkus-3-gradle | gradle | Based on link:https://quarkus.io/[Quarkus 3], with gradle packaging (yaml)
 | quarkus-3-gradle-kts | gradle-kts | Based on link:https://quarkus.io/[Quarkus 3], with gradle kotlin packaging (yaml)
 | quarkus-3-properties | maven | Based on link:https://quarkus.io/[Quarkus 3], with maven packaging (properties)
 | quarkus-2        | maven | Based on link:https://quarkus.io/[Quarkus 2], with maven packaging
-| micronaut-4        | maven | Based on link:https://micronaut.io/[Micronatut], with maven packaging
-| springboot-3        | maven | Based on link:https://spring.io/projects/spring-boot[Sping Boot 3], with maven packaging
+| micronaut-4        | maven | Based on link:https://micronaut.io/[Micronaut], with maven packaging
+| springboot-3        | maven | Based on link:https://spring.io/projects/spring-boot[Spring Boot 3], with maven packaging
 | openliberty        | maven | Based on link:https://openliberty.io/[Open Liberty], with maven packaging
 |====================================================================================================================================
 

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/02_3_maven_plugin_verify.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/02_3_maven_plugin_verify.adoc
@@ -49,7 +49,7 @@ mvn org.fugerit.java:fj-doc-maven-plugin:verify -DtemplateBasePath=./src/test/re
 | freemarkerVersion   | false    | latest stable | FreeMarker configuration ( i.e. 2.3.33)
 | templateFilePattern | false    |               | Filter on templates to be checked, regex on filename, i.e. ".{0,}[.]ftl"
 | failOnErrors        | true     | true          | If set to true the build will fail when template syntax errors will be found, otherwise errors will be only logged
-| generateReport      | false    | false         | If set to true a report will be generated (and property 'reportOutputFolder' will be olso required).
+| generateReport      | false    | false         | If set to true a report will be generated (and property 'reportOutputFolder' will be also required).
 | reportOutputFolder  | false    |               | Output folder for the generated report.
 | reportOutputFormat  | false    | 'html'        | Output format for the generated report, supported : html (default), pdf, csv, xlsx, md.
 |====================================================================================================================================================================

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/02_4_maven_plugin_direct.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/02_4_maven_plugin_direct.adoc
@@ -3,14 +3,14 @@
 
 Allow direct generation
 
-==== Verify at command line
+==== Direct at command line
 
 [source,shell]
 ----
 mvn org.fugerit.java:fj-doc-maven-plugin:verify -DtemplateBasePath=./src/test/resources/fj_doc_test/template-fail
 ----
 
-==== Verify at maven build time
+==== Direct at maven build time
 
 [source,xml]
 ----
@@ -50,7 +50,7 @@ mvn org.fugerit.java:fj-doc-maven-plugin:verify -DtemplateBasePath=./src/test/re
 
 ==== Goal 'direct' generation configuration file
 
-Here is an edample configuration file :
+Here is an example configuration file :
 
 [source,yaml]
 ----
@@ -74,7 +74,7 @@ outputList:
   - outputId: 'test-doc-html'
     chainId: 'test-doc'
     handlerId: 'html' # a valid handler for this output type should be defined (i.e. org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlTypeHandlerUTF8)
-    file: 't${projectBasedir}/arget/test-doc.html'
+    file: '${projectBasedir}/target/test-doc.html'
   - outputId: 'test-doc-md'
     chainId: 'test-doc'
     handlerId: 'md'
@@ -86,9 +86,9 @@ outputList:
   - outputId: 'test-doc-yaml-data-model-md'
     chainId: 'test-doc-yaml-data-model'
     handlerId: 'md'
-    file: '${projectBasedir}/target/test-doc-json-data-model.md'
+    file: '${projectBasedir}/target/test-doc-yaml-data-model.md'
 ----
 
-TIP: _dataModel_ property in chain contains a map that can be used in the template (accessibile as 'dataModel' attribute).
+TIP: _dataModel_ property in chain contains a map that can be used in the template (accessible as 'dataModel' attribute).
 
-NOTE: Instead of maven plugin gola, it is possible to use [fj-doc-lib-direct] module as a standalone library.
+NOTE: Instead of maven plugin goal, it is possible to use [fj-doc-lib-direct] module as a standalone library.

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/03_1_doc_format_xml.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/03_1_doc_format_xml.adoc
@@ -8,7 +8,7 @@ When writing a sample Venus Document, it is possible to draw from some online re
 . https://venusdocs.fugerit.org/docs/html/doc_meta_info.html[Venus DOC meta informations reference] - documentations for existing 'info' properties for 'metadata' section.
 . https://docs.fugerit.org/fj-doc-playground/home/[Online Playground] - To test how the XML elements are rendered to documents by DocHandlers.
 
-Supported is provided by the base module dependency :
+Support is provided by the base module dependency :
 
 [source,xml]
 ----

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/03_3_doc_format_kotlin.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/03_3_doc_format_kotlin.adoc
@@ -1,7 +1,7 @@
 [#doc-format-entry-point-kotlin]
 === Kotlin Source Format (Experimental)
 
-Supported is provided by the base module dependency.
+Support is provided by the base module dependency.
 
 [source,xml]
 ----

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/03_5_doc_extra_feature.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/03_5_doc_extra_feature.adoc
@@ -6,7 +6,7 @@ Some extra features are available on the Venus Doc Format. Here is a listing.
 [#doc-format-entry-point-extra-feature-table-check-integrity]
 ==== Table Check Integrity
 
-Sometimes using table with wrong number of columns and rows anc lead to unexpected behaviour or errors.
+Sometimes using a table with the wrong number of columns and rows can lead to unexpected behaviour or errors.
 
 Using the doc info 'table-check-integrity' can solve this issue, for instance :
 
@@ -15,7 +15,7 @@ Using the doc info 'table-check-integrity' can solve this issue, for instance :
 <info name="table-check-integrity">fail</info>
 ----
 
-link:https://venusdocs.fugerit.org/docs/html/doc_meta_info.html#table-check-integrity[Here is  'table-check-integrity' documentation].
+link:https://venusdocs.fugerit.org/docs/html/doc_meta_info.html#table-check-integrity[Here is the 'table-check-integrity' documentation].
 
 Accepted values are :
 

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/04_1_doc_freemarker_config.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/04_1_doc_freemarker_config.adoc
@@ -43,7 +43,7 @@ Aside from namespace declaration, it is possible to set some general attribute f
 | *failOnValidate* anchor:doc-freemarker-config-attributes-failOnValidate[]
 | _boolean_
 | _false_
-| If set to 'true' the FreemarkerDocProcessConfig will fail in case of validation errors, if 'false' will just print the result as warning. (since 8.9.1), NOTE: 'validating' is set to true, this attribute is ignored. See also xref:#doc-faq-validate-document[FAQ]
+| If set to 'true' the FreemarkerDocProcessConfig will fail in case of validation errors, if 'false' will just print the result as warning. (since 8.9.1), NOTE: if 'validating' is NOT set to true, this attribute is ignored. See also xref:#doc-faq-validate-document[FAQ]
 
 | *cleanSource*  anchor:doc-freemarker-config-attributes-cleanSource[]
 | _boolean_
@@ -67,7 +67,7 @@ The main elements are the *<docHandlerConfig/>* containing the available output 
     <docHandlerConfig registerById="true">
         <!-- Type handler for markdown format -->
         <docHandler id="md-ext" info="md" type="org.fugerit.java.doc.base.typehandler.markdown.SimpleMarkdownExtTypeHandler" />
-        <!-- Type henalder for xml format, generates the source xml:doc -->
+        <!-- Type handler for xml format, generates the source xml:doc -->
         <docHandler id="xml-doc" info="xml" type="org.fugerit.java.doc.base.config.DocTypeHandlerXMLUTF8" />
         <!-- Type handler for html using freemarker -->
         <docHandler id="html-fm" info="html" type="org.fugerit.java.doc.freemarker.html.FreeMarkerHtmlTypeHandlerEscapeUTF8" />

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/04_3_doc_freemarker_usage.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/04_3_doc_freemarker_usage.adoc
@@ -22,7 +22,7 @@ public class DocHelper {
 }
 ----
 
-And for instance a rest serive to expose the api :
+And for instance a REST service to expose the API :
 
 [source,java]
 ----
@@ -54,7 +54,7 @@ public class DocResource {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             // creates the doc helper
             DocHelper docHelper = new DocHelper();
-            // create custom data for the fremarker template 'document.ftl'
+            // create custom data for the freemarker template 'document.ftl'
             List<People> listPeople = Arrays.asList(new People("Luthien", "Tinuviel", "Queen"), new People("Thorin", "Oakshield", "King"));
             // output generation
             docHelper.getDocProcessConfig().fullProcess("document", DocProcessContext.newContext("listPeople", listPeople), handlerId, baos);

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/06_3_mod-poi.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/06_3_mod-poi.adoc
@@ -71,7 +71,7 @@ More elements specific to excel format are available link:https://venusdocs.fuge
 [#doc-handler-mod-poi-xlsx]
 ==== Xlsx DocHandler
 
-This doc handler would a XLSX document.
+This doc handler would render a XLSX document.
 
 *In brief* :
 
@@ -83,7 +83,7 @@ Add this element to *<docHandlerConfig/>* :
 
 [source,xml]
 ----
-<!-- XLSX type hanlder  -->
+<!-- XLSX type handler  -->
 <docHandler id="xlsx-poi" info="xlsx" type="org.fugerit.java.doc.mod.poi.XlsxPoiTypeHandler" />
 ----
 
@@ -92,7 +92,7 @@ For a demo of this doc handler usage you can refer to the link:https://github.co
 [#doc-handler-mod-poi-xls]
 ==== Xls DocHandler
 
-This doc handler would a XLS document.
+This doc handler would render a XLS document.
 
 *In brief* :
 
@@ -104,6 +104,6 @@ Add this element to *<docHandlerConfig/>* :
 
 [source,xml]
 ----
-<!-- XLSX type hanlder  -->
+<!-- XLS type handler  -->
 <docHandler id="xls-poi" info="xlsx" type="org.fugerit.java.doc.mod.poi.XlsPoiTypeHandler" />
 ----

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/06_5_mod-openpdf-ext.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/06_5_mod-openpdf-ext.adoc
@@ -25,7 +25,7 @@ This module is based on link:https://github.com/LibrePDF/OpenPDF/[OpenPDF] (base
 [#doc-handler-mod-openpdf-ext-pdf]
 ==== [fj-doc-mod-openpdf-ext-pdf] : PDF DocHandler
 
-This doc handler would a PDF document.
+This doc handler would render a PDF document.
 
 Add this element to *<docHandlerConfig/>* :
 
@@ -48,7 +48,7 @@ More elements specific to fixed size formats, like PDF, are available link:https
 | *charset* anchor:doc-handler-mod-openpdf-ext-pdf-charset[]  | _string_  | _UTF-8_ | This will set the charset to use.
 |========================================================================================================================================
 
-Additionaly *fonts* can be configured as child elements of *docHandlerCustomConfig*
+Additionally, *fonts* can be configured as child elements of *docHandlerCustomConfig*
 
 [cols="2,1,1,6", options="header"]
 |========================================================================================================================================
@@ -72,7 +72,7 @@ Here is a custom configuration example :
 [#doc-handler-mod-openpdf-ext-html]
 ==== [fj-doc-mod-openpdf-ext-html] : HTML DocHandler
 
-This doc handler would a HTML document.
+This doc handler would render a HTML document.
 
 *In brief* :
 
@@ -84,7 +84,7 @@ Add this element to *<docHandlerConfig/>* :
 
 [source,xml]
 ----
-<!-- OpenHTML type hanlder  -->
+<!-- OpenHTML type handler  -->
 <docHandler id="openpdf-html" info="openpdf-html" type="org.fugerit.java.doc.mod.openpdf.ext.HtmlTypeHandler"/>
 ----
 

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/06_6_mod-openrtf-ext.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/06_6_mod-openrtf-ext.adoc
@@ -22,13 +22,13 @@ To use this doc handler, you will need to add the following dependency :
 
 This module is based on link:https://github.com/LibrePDF/OpenRTF[OpenRTF].
 
-This doc handler would a RTF document.
+This doc handler would render a RTF document.
 
 Add this element to *<docHandlerConfig/>* :
 
 [source,xml]
 ----
-<!-- OpenRTF type hanlder  -->
+<!-- OpenRTF type handler  -->
 <docHandler id="openrtf" info="openrtf" type="org.fugerit.java.doc.mod.openrtf.ext.RtfTypeHandler"/>
 ----
 

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/07_011-xml-apis.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/07_011-xml-apis.adoc
@@ -1,9 +1,9 @@
 [#doc-faq-xml-apis]
-=== Exception javax.xml.parsers.FactoryConfigurationError: Provider org.apache.xerces.jaxp.DocumentBuilderFactoryImpl not found
+=== FactoryConfigurationError: DocumentBuilderFactoryImpl not found
 
 ==== The Problem
 
-If you are receiving the exception:
+If you are receiving the following exception:
 
 [source,txt]
 ----
@@ -18,39 +18,34 @@ javax.xml.parsers.FactoryConfigurationError: Provider org.apache.xerces.jaxp.Doc
 
 ==== Why Does This Error Occur?
 
-The `FactoryConfigurationError` with provider `org.apache.xerces.jaxp.DocumentBuilderFactoryImpl not found` occurs when:
+The root cause is the `xml-apis` artifact — an old library that re-packages XML APIs (`javax.xml.parsers`, `javax.xml.transform`, etc.) that have been part of the JDK natively for many versions. When this library is present on the classpath alongside a modern JDK, it creates a conflict:
 
-1. **Dependency Conflict**: The `xml-apis` dependency (an old Java library) creates a conflict with the modern XML APIs provided by the JDK itself
-2. **Classpath Issues**: The JDK's `DocumentBuilderFactory` class cannot locate the Xerces implementation due to classpath management
-3. **Modularity Problem**: On modern frameworks like Quarkus and Spring Boot, class loading is more rigorous and does not tolerate duplicate XML APIs
-
-The `xml-apis` dependency is now obsolete: XML APIs (`javax.xml.parsers`, `javax.xml.transform`, etc.) have been included natively in the JDK for many versions. When this old library is present on the classpath, it causes resolution conflicts.
-
-==== Why Does the Exclusion Fix This?
-
-By adding the exclusion of the `xml-apis` dependency:
-
-* **Eliminates the conflict**: Removes the obsolete package from the classpath
-* **Uses native JDK APIs**: The system uses the XML implementations provided directly by the Java Runtime Environment
-* **Restores the Service Loader**: Java can correctly locate the `DocumentBuilderFactory` provider through the Service Provider Interface (SPI) mechanism
+1. **Dependency Conflict**: The `xml-apis` artifact shadows the JDK's own XML API classes.
+2. **Classpath Issues**: The JDK's `DocumentBuilderFactory` can no longer locate the Xerces implementation via the Service Provider Interface (SPI).
+3. **Modularity Problem**: Modern frameworks like Quarkus and Spring Boot use more rigorous classloaders and do not tolerate such duplicate classes.
 
 ==== Solution
 
-Add the exclusion to your `pom.xml`:
+The fix is to exclude the `xml-apis` artifact from your dependency in `pom.xml`:
 
 [source,xml]
 ----
 <dependency>
     <groupId>org.fugerit.java</groupId>
     <artifactId>fj-doc-mod-fop</artifactId>
+    <version>${fj-doc-version}</version>
     <exclusions>
         <exclusion>
-            <artifactId>xml-apis</artifactId>
             <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
         </exclusion>
     </exclusions>
 </dependency>
 ----
+
+This removes the obsolete package from the classpath, allowing the JDK to correctly resolve `DocumentBuilderFactory` through its built-in SPI mechanism.
+
+NOTE: The xref:#goal-add-parameters[Maven Plugin `add` goal] provides the `excludeXmlApis` parameter to apply this exclusion automatically during project setup.
 
 [NOTE]
 ====
@@ -58,9 +53,10 @@ Add the exclusion to your `pom.xml`:
 
 If you are using modern microservices frameworks like **Quarkus** or **Spring Boot**, this exclusion is **almost always necessary**. These frameworks:
 
-* Use more rigorous classloaders to reduce overhead
-* Do not easily tolerate duplicate classes on the classpath
-* Require a clean and predictable environment for AOT (Ahead-of-Time) compilation and native image generation
+* Use rigorous classloaders to reduce overhead
+* Do not tolerate duplicate classes on the classpath
+* Require a clean, predictable environment for AOT compilation and native image generation
 
-If you do not apply this exclusion on Quarkus or Spring Boot, you will very likely encounter this error during the build phase or at runtime. Therefore, it is recommended to apply this exclusion **from the start** if you are using one of these frameworks.
+It is recommended to apply this exclusion **from the start** when using one of these frameworks.
 ====
+

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/07_012-mod-fop-FWK005.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/07_012-mod-fop-FWK005.adoc
@@ -5,10 +5,12 @@
 Using transformer inside transformer fails on JDK 25, works on older JDKs (11,17,21).
 
 * link:https://bugs.openjdk.org/browse/JDK-8368356[JDK-8368356 : TransformerException: org.xml.sax.SAXException: FWK005 parse may not be called while parsing]
-* link:https://bugs.openjdk.org/browse/JDK-8368356[FOP-3275 : Support for Java 25 (Error reading event-model.xml: org.xml.sax.SAXException: FWK005 parse may not be called while parsing.)]
+* link:https://issues.apache.org/jira/browse/FOP-3275[FOP-3275 : Support for Java 25 (Error reading event-model.xml: org.xml.sax.SAXException: FWK005 parse may not be called while parsing.)]
 * link:https://github.com/fugerit-org/fj-doc/issues/502[Support for Java 25 (Error reading event-model.xml: org.xml.sax.SAXException: FWK005 parse may not be called while parsing.)]
 
-A possibile workaround, proposed by link:https://issues.apache.org/jira/browse/FOP-3275[Thomas Mortagne], is to add link:https://www.saxonica.com/documentation12/documentation.xml[Saxon-HE] alternative transformer.
+NOTE: Since version *8.18.1*, `fj-doc-mod-fop` automatically applies this workaround when running on JDK 25+. No manual configuration is required if you are using that version or later.
+
+A possible workaround, proposed by link:https://issues.apache.org/jira/browse/FOP-3275[Thomas Mortagne], is to add link:https://www.saxonica.com/documentation12/documentation.xml[Saxon-HE] as an alternative transformer.
 
 [source,xml]
 ----

--- a/fj-doc-guide/src/main/docs/asciidoc/chapters/08_doc-optmization.adoc
+++ b/fj-doc-guide/src/main/docs/asciidoc/chapters/08_doc-optmization.adoc
@@ -3,4 +3,4 @@
 [#doc-optimization]
 == Optimizations
 
-In this chapter the main Venus optimizations ara described.
+In this chapter the main Venus optimizations are described.


### PR DESCRIPTION
Fix typos and grammar in AsciiDoc guide chapters, improve xml-apis FAQ section.